### PR TITLE
Per-folder storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 	<p>
 		<a href='https://github.com/obsidianmd/obsidian-releases/blob/master/community-plugin-stats.json#:~:text="flexplorer"' target="_blank"><img src="https://img.shields.io/badge/dynamic/json?logo=obsidian&style=flat-square&color=D6CFCB&labelColor=49355E&label=Downloads&query=%24%5B%22flexplorer%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json" alt="downloads"></a>&nbsp;
 		<a href="https://github.com/kh4f/flexplorer/releases"><img src="https://img.shields.io/github/v/tag/kh4f/flexplorer?label=%F0%9F%8F%B7%EF%B8%8F%20Release&style=flat-square&color=D6CFCB&labelColor=49355E" alt="version"/></a>&nbsp;
-		<a href="https://github.com/kh4f/flexplorer/issues?q=is%3Aissue+is%3Aopen+label%3Abug"><img src="https://img.shields.io/github/issues/kh4f/flexplorer/bug?label=%F0%9F%90%9B%20Bugs&style=flat-square&color=D6CFCB&labelColor=49355E" alt="bugs"></a>
+		<a href="https://github.com/kh4f/flexplorer/issues?q=is%3Aopen+label%3Abug"><img src="https://img.shields.io/github/issues/kh4f/flexplorer/bug?label=%F0%9F%90%9B%20Bugs&style=flat-square&color=D6CFCB&labelColor=49355E" alt="bugs"></a>
 	</p>
 	<b>
 		<a href="#-features">Features</a>&nbsp; •&nbsp;
 		<a href="#%EF%B8%8F-usage">Usage</a>&nbsp; •&nbsp;
+		<a href="#-per-folder-storage">Per-folder storage</a>&nbsp; •&nbsp;
 		<a href="#-installation">Installation</a>&nbsp; •&nbsp;
 		<a href="#-credits">Credits</a>
 	</b>
@@ -26,12 +27,93 @@
 - **Custom order mode:** manually arrange items via drag-and-drop
 - **Pinning & hiding:** keep important files at the top, hide irrelevant ones
 - **Mobile support:** all features work on mobile as well
+- **Per-folder storage mode:** store ordering and visibility per folder for Git-friendly collaboration
 
 ## 🕹️ Usage
 ![guide](https://raw.githubusercontent.com/kh4f/flexplorer/refs/heads/assets/guide.png)
 
 #### Notes:
 - To drag items on touch devices, hold them **by the right edge**
+
+## 📁 Per-folder storage
+
+Per-folder storage is an optional Git-friendly storage mode for collaborative vaults.
+
+Instead of storing the state of the entire vault in one plugin data file (`.obsidian/plugins/flexplorer/data.json`), Flexplorer stores each folder's ordering and visibility state in a local `.flexplorer.json` file inside that folder.
+
+### When to use it
+
+- **Collaborative vaults** shared via Git, Obsidian Sync, or Syncthing
+- **Large vaults** where different people maintain different sections
+- **Any setup** where a single `data.json` causes sync conflicts
+
+### How it works
+
+```
+Vault/
+├── .flexplorer.json          ← root folder order
+├── Documentation/
+│   ├── .flexplorer.json      ← Documentation folder order
+│   ├── Introduction.md
+│   ├── FAQ.md
+│   └── Configuration/
+│       ├── .flexplorer.json  ← Configuration folder order
+│       ├── General.md
+│       └── Advanced.md
+└── Development/
+    ├── .flexplorer.json      ← Development folder order
+    ├── Roadmap.md
+    └── Internal.md
+```
+
+Each `.flexplorer.json` file controls **only its immediate children**:
+
+```json
+{
+"version": 1,
+"order": ["Introduction.md", "Configuration", "FAQ.md"],
+"hidden": ["Internal.md"],
+"pinned": ["Introduction.md"]
+}
+```
+
+### How to enable
+
+1. Open **Settings → Flexplorer → Storage**
+2. Change **Storage mode** to `Per-folder metadata files`
+3. If you have existing ordering data, choose **Migrate data** when prompted
+
+### Migration commands
+
+Accessible via the command palette (`Ctrl/Cmd+P`):
+
+| Command | Description |
+|---------|-------------|
+| `Flexplorer: Migrate data.json to per-folder storage` | Create `.flexplorer.json` files from existing `data.json` data |
+| `Flexplorer: Preview migration to per-folder storage` | Dry-run — shows what will happen without writing anything |
+| `Flexplorer: Migrate per-folder storage to data.json` | Reverse migration: collect all `.flexplorer.json` back into `data.json` |
+| `Flexplorer: Validate per-folder metadata files` | Check all `.flexplorer.json` files for errors and stale references |
+| `Flexplorer: Reload folder metadata` | Clear cache and re-read all `.flexplorer.json` files |
+
+### Git conflicts
+
+Per-folder storage minimises merge conflicts:
+
+- **Different folders** edited by different people → **no conflict**
+- **Same folder** edited by two people → conflict is **localised to one small `.flexplorer.json` file**
+- **Renaming or moving a folder** → internal metadata stays intact
+
+To opt out of synchronising metadata entirely, add this to your `.gitignore`:
+
+```gitignore
+**/.flexplorer.json
+```
+
+> **Note:** With the gitignore line, every user will have their own local ordering — changes won't sync.
+
+### Going back
+
+To return to the single-file mode, use `Flexplorer: Migrate per-folder storage to data.json`. The `.flexplorer.json` files are **not automatically deleted** — use the command `Flexplorer: Remove per-folder metadata files` (if available) or delete them manually.
 
 ## 📥 Installation
 - **Via the Obsidian Community**: https://community.obsidian.md/plugins/flexplorer

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build": "bun prod",
 		"typecheck": "tsc",
 		"lint": "eslint",
+		"test": "bun test",
 		"release": "bunx relion -b manifest.json -t ''"
 	},
 	"devDependencies": {

--- a/src/__tests__/path-utils.test.ts
+++ b/src/__tests__/path-utils.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	childPrefix,
+	emptyFolderState,
+	getMetadataPath,
+	getName,
+	getParentPath,
+	isDirectChild,
+	isFolderStateEmpty,
+	pruneStaleReferences,
+	serialiseFolderState,
+	validateMetadataFilename,
+} from '../core/storage/path-utils'
+
+// ── getMetadataPath ────────────────────────────────────────────────
+
+describe('getMetadataPath', () => {
+	test('root folder returns bare filename', () => {
+		expect(getMetadataPath('')).toBe('.flexplorer.json')
+		expect(getMetadataPath('/')).toBe('.flexplorer.json')
+	})
+
+	test('nested folder joins with slash', () => {
+		expect(getMetadataPath('Documentation')).toBe('Documentation/.flexplorer.json')
+		expect(getMetadataPath('A/B/C')).toBe('A/B/C/.flexplorer.json')
+	})
+
+	test('strips leading/trailing slashes', () => {
+		expect(getMetadataPath('/Documentation/')).toBe('Documentation/.flexplorer.json')
+	})
+
+	test('custom filename', () => {
+		expect(getMetadataPath('Docs', '.meta.json')).toBe('Docs/.meta.json')
+	})
+})
+
+// ── getParentPath ──────────────────────────────────────────────────
+
+describe('getParentPath', () => {
+	test('root returns /', () => {
+		expect(getParentPath('/')).toBe('/')
+	})
+
+	test('top-level file returns /', () => {
+		expect(getParentPath('Readme.md')).toBe('/')
+	})
+
+	test('nested file returns parent folder', () => {
+		expect(getParentPath('Doc/Readme.md')).toBe('Doc')
+		expect(getParentPath('A/B/C/File.md')).toBe('A/B/C')
+	})
+})
+
+// ── getName ─────────────────────────────────────────────────────────
+
+describe('getName', () => {
+	test('top-level file returns itself', () => {
+		expect(getName('Readme.md')).toBe('Readme.md')
+	})
+
+	test('nested file returns leaf name', () => {
+		expect(getName('Doc/File.md')).toBe('File.md')
+		expect(getName('A/B/C/File.md')).toBe('File.md')
+	})
+
+	test('empty for root', () => {
+		expect(getName('/')).toBe('')
+	})
+})
+
+// ── childPrefix ────────────────────────────────────────────────────
+
+describe('childPrefix', () => {
+	test('root returns empty string', () => {
+		expect(childPrefix('/')).toBe('')
+	})
+
+	test('folder returns with trailing slash', () => {
+		expect(childPrefix('Doc')).toBe('Doc/')
+		expect(childPrefix('A/B/C')).toBe('A/B/C/')
+	})
+})
+
+// ── isDirectChild ──────────────────────────────────────────────────
+
+describe('isDirectChild', () => {
+	test('root children', () => {
+		expect(isDirectChild('Readme.md', '/')).toBe(true)
+		expect(isDirectChild('Folder', '/')).toBe(true)
+	})
+
+	test('nested children', () => {
+		expect(isDirectChild('Doc/Readme.md', 'Doc')).toBe(true)
+		expect(isDirectChild('Doc/Sub/Readme.md', 'Doc')).toBe(false)
+	})
+
+	test('self is not child', () => {
+		expect(isDirectChild('/', '/')).toBe(false)
+		expect(isDirectChild('Doc', 'Doc')).toBe(false)
+	})
+})
+
+// ── validateMetadataFilename ───────────────────────────────────────
+
+describe('validateMetadataFilename', () => {
+	test('valid names', () => {
+		expect(validateMetadataFilename('.flexplorer.json')).toBeNull()
+		expect(validateMetadataFilename('metadata.json')).toBeNull()
+	})
+
+	test('empty', () => {
+		expect(validateMetadataFilename('')).toBe('Filename must not be empty')
+	})
+
+	test('contains slash', () => {
+		const err = validateMetadataFilename('path/file.json')
+		expect(err).toContain('/ or \\')
+	})
+
+	test('special dir names', () => {
+		expect(validateMetadataFilename('.')).toContain('not be')
+		expect(validateMetadataFilename('..')).toContain('not be')
+	})
+})
+
+// ── serialiseFolderState ───────────────────────────────────────────
+
+describe('serialiseFolderState', () => {
+	test('produces stable JSON with trailing newline', () => {
+		const state = { version: 1, order: ['a.md', 'b.md'], hidden: [], pinned: [] }
+		const result = serialiseFolderState(state)
+		expect(result.endsWith('\n')).toBe(true)
+		const parsed = JSON.parse(result)
+		expect(parsed.version).toBe(1)
+		expect(parsed.order).toEqual(['a.md', 'b.md'])
+	})
+
+	test('keys in deterministic order', () => {
+		const state = { version: 1, order: ['a'], hidden: ['b'], pinned: [], sortMode: 'custom' as const }
+		const lines = serialiseFolderState(state).split('\n')
+		// First data line should be  "version":
+		expect(lines[1].trim()).toBe('"version": 1,')
+	})
+
+	test('preserves unknown extension fields sorted', () => {
+		const state = { version: 1, order: [], hidden: [], pinned: [], groups: ['x'], zField: 1 }
+		const result = serialiseFolderState(state)
+		const parsed = JSON.parse(result)
+		expect(parsed.groups).toEqual(['x'])
+		expect(parsed.zField).toBe(1)
+	})
+})
+
+// ── emptyFolderState ───────────────────────────────────────────────
+
+describe('emptyFolderState', () => {
+	test('creates empty state v1', () => {
+		const state = emptyFolderState()
+		expect(state.version).toBe(1)
+		expect(state.order).toEqual([])
+		expect(state.hidden).toEqual([])
+		expect(state.pinned).toEqual([])
+	})
+})
+
+// ── isFolderStateEmpty ─────────────────────────────────────────────
+
+describe('isFolderStateEmpty', () => {
+	test('truly empty', () => {
+		expect(isFolderStateEmpty(emptyFolderState())).toBe(true)
+	})
+
+	test('not empty when has order', () => {
+		const state = emptyFolderState()
+		state.order = ['a']
+		expect(isFolderStateEmpty(state)).toBe(false)
+	})
+
+	test('empty with sortMode custom is still empty', () => {
+		const state = emptyFolderState()
+		state.sortMode = 'custom'
+		expect(isFolderStateEmpty(state)).toBe(true)
+	})
+
+	test('not empty with non-custom sortMode', () => {
+		const state = emptyFolderState()
+		state.sortMode = 'byName'
+		expect(isFolderStateEmpty(state)).toBe(false)
+	})
+})
+
+// ── pruneStaleReferences ───────────────────────────────────────────
+
+describe('pruneStaleReferences', () => {
+	test('removes non-existent names from all arrays', () => {
+		const state = {
+			version: 1,
+			order: ['a.md', 'b.md', 'gone.md'],
+			hidden: ['gone.md'],
+			pinned: ['a.md'],
+		}
+		const existing = new Set(['a.md', 'b.md'])
+		const pruned = pruneStaleReferences(state, existing)
+		expect(pruned.order).toEqual(['a.md', 'b.md'])
+		expect(pruned.hidden).toEqual([])
+		expect(pruned.pinned).toEqual(['a.md'])
+	})
+
+	test('does not mutate original', () => {
+		const state = { version: 1, order: ['gone.md'], hidden: [], pinned: [] }
+		const existing = new Set<string>()
+		pruneStaleReferences(state, existing)
+		expect(state.order).toEqual(['gone.md'])
+	})
+})

--- a/src/core/order-manager.ts
+++ b/src/core/order-manager.ts
@@ -4,6 +4,8 @@ import type { FileTreeItem } from 'obsidian-typings'
 import { initLog } from '@/utils'
 import type Flexplorer from '@/plugin'
 import type { BaseItemSettings, FolderSettings, SortOrder } from '@/types'
+import { getParentPath, getName, emptyFolderState, isFolderStateEmpty, childPrefix, isDirectChild } from '@/core/storage'
+import type { FolderState } from '@/core/storage'
 
 const DEFAULT_ITEM_SETTINGS: BaseItemSettings = { isPinned: false, isHidden: false }
 const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true })
@@ -16,7 +18,13 @@ export class OrderManager {
 	syncItems(root = this.plugin.app.vault.root) {
 		this.log(`Syncing items with vault in root '${root.path}'`)
 		this.cleanUpInvalidPaths()
-		this.sync(root)
+
+		if (this.plugin.settings.storageMode === 'per-folder') {
+			this.syncPerFolder(root)
+		} else {
+			this.sync(root)
+		}
+
 		this.persistAndLog('Items synced:')
 	}
 
@@ -26,7 +34,8 @@ export class OrderManager {
 
 		const items = this.plugin.settings.items
 		const isFolder = item instanceof TFolder
-		const parentItem = items[item.parent!.path] as FolderSettings
+		const parentPath = item.parent!.path
+		const parentItem = items[parentPath] as FolderSettings
 
 		items[item.path] = {
 			...DEFAULT_ITEM_SETTINGS,
@@ -36,7 +45,7 @@ export class OrderManager {
 		if (insertPos === 'top') parentItem.customOrder.unshift(item.name)
 		else parentItem.customOrder.push(item.name)
 
-		this.persistCreateDeleteChange('Order updated after item creation:')
+		this.persistCreateDeleteChange('Order updated after item creation:', parentPath)
 	}
 
 	move(from: string, to: string, siblingPath?: string, pos?: 'before' | 'after') {
@@ -44,10 +53,10 @@ export class OrderManager {
 		if (from === to && siblingPath === to) return this.log('No move needed')
 
 		const items = this.plugin.settings.items
-		const fromName = this.getName(from)
-		const toName = this.getName(to)
-		const fromParentPath = this.getParentPath(from)
-		const toParentPath = this.getParentPath(to)
+		const fromName = getName(from)
+		const toName = getName(to)
+		const fromParentPath = getParentPath(from)
+		const toParentPath = getParentPath(to)
 		const fromParent = items[fromParentPath] as FolderSettings | undefined
 		const toParent = items[toParentPath] as FolderSettings | undefined
 		const parentChanged = fromParentPath !== toParentPath
@@ -64,7 +73,7 @@ export class OrderManager {
 
 			let insertIndex = 0
 			if (siblingPath) {
-				const siblingIndex = toParent.customOrder.indexOf(this.getName(siblingPath))
+				const siblingIndex = toParent.customOrder.indexOf(getName(siblingPath))
 				insertIndex = pos === 'before' ? siblingIndex : siblingIndex + 1
 			} else if (!parentChanged) {
 				insertIndex = fromIndex
@@ -79,7 +88,7 @@ export class OrderManager {
 			if (!toParent.customOrder.includes(toName)) toParent.customOrder.splice(insertIndex, 0, toName)
 		}
 
-		this.persistAndLog('Order updated:')
+		this.persistAndLog('Order updated:', [fromParentPath, toParentPath])
 
 		if (!parentChanged) {
 			this.log('Directory did not change, sorting explorer')
@@ -91,15 +100,104 @@ export class OrderManager {
 		this.log(`Removing '${path}'`)
 
 		const items = this.plugin.settings.items
-		const name = this.getName(path)
-		const parentItem = items[this.getParentPath(path)] as FolderSettings
+		const name = getName(path)
+		const parentPath = getParentPath(path)
+		const parentItem = items[parentPath] as FolderSettings
 
 		delete items[path]
 
 		parentItem.customOrder = parentItem.customOrder.filter(p => p !== name)
 
-		this.persistCreateDeleteChange('Order updated after item deletion:')
+		this.persistCreateDeleteChange('Order updated after item deletion:', parentPath)
+
+		// If the deleted item was a folder with its own metadata, clean it up
+		if (this.plugin.settings.storageMode === 'per-folder') {
+			void this.plugin.deleteFolderState(path)
+		}
 	}
+
+	getSortedItems(
+		folderSettings: FolderSettings,
+		items: FileTreeItem[],
+		sortOrder: SortOrder = folderSettings.sortOrder,
+	): FileTreeItem[] {
+		return items.slice().sort((aItem, bItem) => {
+			const [a, b] = [aItem.file, bItem.file]
+			const isAPinned = this.plugin.settings.items[a.path]?.isPinned ?? false
+			const isBPinned = this.plugin.settings.items[b.path]?.isPinned ?? false
+			if (isAPinned !== isBPinned) return isAPinned ? -1 : 1
+
+			if (sortOrder !== 'custom') {
+				const isAFolder = a instanceof TFolder
+				const isBFolder = b instanceof TFolder
+				if (isAFolder !== isBFolder) return isAFolder ? -1 : 1
+			}
+
+			switch (sortOrder) {
+				case 'custom': {
+					const aIndex = folderSettings.customOrder.indexOf(a.name)
+					const bIndex = folderSettings.customOrder.indexOf(b.name)
+					if (aIndex === -1 || bIndex === -1) return this.compareByName(a, b)
+					return aIndex - bIndex
+				}
+				case 'byNameReverse': return this.compareByName(b, a)
+				case 'byCreatedTime': return this.compareByTimestamp(a, b, 'ctime', 'asc')
+				case 'byCreatedTimeReverse': return this.compareByTimestamp(a, b, 'ctime', 'desc')
+				case 'byModifiedTime': return this.compareByTimestamp(a, b, 'mtime', 'asc')
+				case 'byModifiedTimeReverse': return this.compareByTimestamp(a, b, 'mtime', 'desc')
+				case 'byName':
+				default: return this.compareByName(a, b)
+			}
+		})
+	}
+
+	// ── Per-folder mode helpers ──────────────────────────────────────
+
+	/**
+	 * In per-folder mode, update `settings.items` after a folder state
+	 * has been modified so that the runtime representation stays in sync.
+	 */
+	applyFolderStateToRuntime(folderPath: string, state: FolderState): void {
+		const items = this.plugin.settings.items
+		const prefix = childPrefix(folderPath)
+
+		// Folder entry — preserve isPinned/isHidden set by parent folder
+		const existing = items[folderPath] as Record<string, unknown> | undefined
+		items[folderPath] = {
+			...(existing ?? {}),
+			customOrder: state.order,
+			sortOrder: state.sortMode ?? 'custom',
+		} as FolderSettings
+
+		// Remove old child entries that are no longer referenced
+		const referencedNames = new Set([...state.order, ...state.hidden, ...state.pinned])
+		for (const key of Object.keys(items)) {
+			if (isDirectChild(key, folderPath)) {
+				const name = getName(key)
+				if (!referencedNames.has(name)) {
+					delete items[key]
+				}
+			}
+		}
+
+		// Add hidden/pinned entries
+		for (const name of state.hidden) {
+			const path = prefix + name
+			const existing = (items[path] as Record<string, unknown>) ?? {}
+			items[path] = { ...DEFAULT_ITEM_SETTINGS, ...existing, isHidden: true } as BaseItemSettings
+		}
+
+		for (const name of state.pinned) {
+			const path = prefix + name
+			const existing = (items[path] as Record<string, unknown>) ?? {}
+			items[path] = { ...DEFAULT_ITEM_SETTINGS, ...existing, isPinned: true } as BaseItemSettings
+			if (!this.plugin.settings.pinnedFiles.includes(path)) {
+				this.plugin.settings.pinnedFiles.push(path)
+			}
+		}
+	}
+
+	// ── Private ──────────────────────────────────────────────────────
 
 	private sync(folder: TFolder) {
 		const folderPath = folder.path
@@ -133,6 +231,48 @@ export class OrderManager {
 		}
 	}
 
+	private syncPerFolder(folder: TFolder) {
+		const folderPath = folder.path
+		const newChildren = folder.children.map(c => c.name)
+
+		// Try to load existing state from the storage backend first
+		// This preserves custom order, hidden, and pinned from .flexplorer.json
+		void this.plugin.loadFolderState(folderPath).then(existingState => {
+			const state = existingState ?? emptyFolderState()
+
+			// Merge children: keep existing order, add new children
+			const existingOrder = state.order.filter(p => newChildren.includes(p))
+			const addedChildren = newChildren.filter(p => !state.order.includes(p))
+			state.order = this.plugin.settings.newItemPlacement === 'top'
+				? [...addedChildren, ...existingOrder]
+				: [...existingOrder, ...addedChildren]
+
+			this.applyFolderStateToRuntime(folderPath, state)
+		})
+
+		// In the meantime, create a minimal runtime entry so the tree can render
+		if (!this.plugin.settings.items[folderPath]) {
+			this.plugin.settings.items[folderPath] = {
+				...DEFAULT_ITEM_SETTINGS,
+				sortOrder: 'custom',
+				customOrder: newChildren,
+			}
+		}
+
+		// Recursively sync children
+		for (const child of folder.children) {
+			if (child instanceof TFolder) {
+				this.syncPerFolder(child)
+				continue
+			}
+
+			if (child instanceof TFile) {
+				const prevSettings = this.plugin.settings.items[child.path] as BaseItemSettings | undefined
+				this.plugin.settings.items[child.path] = { ...DEFAULT_ITEM_SETTINGS, ...prevSettings }
+			}
+		}
+	}
+
 	private cleanUpInvalidPaths() {
 		for (const path of Object.keys(this.plugin.settings.items)) {
 			if (!this.plugin.app.vault.getAbstractFileByPath(path)) {
@@ -147,41 +287,6 @@ export class OrderManager {
 		this.plugin.settings.pinnedFiles = this.plugin.settings.pinnedFiles.unique()
 	}
 
-	getSortedItems(
-		folderSettings: FolderSettings,
-		items: FileTreeItem[],
-		sortOrder: SortOrder = folderSettings.sortOrder,
-	): FileTreeItem[] {
-		return items.slice().sort((aItem, bItem) => {
-			const [a, b] = [aItem.file, bItem.file]
-			const isAPinned = this.plugin.settings.items[a.path].isPinned
-			const isBPinned = this.plugin.settings.items[b.path].isPinned
-			if (isAPinned !== isBPinned) return isAPinned ? -1 : 1
-
-			if (sortOrder !== 'custom') {
-				const isAFolder = a instanceof TFolder
-				const isBFolder = b instanceof TFolder
-				if (isAFolder !== isBFolder) return isAFolder ? -1 : 1
-			}
-
-			switch (sortOrder) {
-				case 'custom': {
-					const aIndex = folderSettings.customOrder.indexOf(a.name)
-					const bIndex = folderSettings.customOrder.indexOf(b.name)
-					if (aIndex === -1 || bIndex === -1) return this.compareByName(a, b)
-					return aIndex - bIndex
-				}
-				case 'byNameReverse': return this.compareByName(b, a)
-				case 'byCreatedTime': return this.compareByTimestamp(a, b, 'ctime', 'asc')
-				case 'byCreatedTimeReverse': return this.compareByTimestamp(a, b, 'ctime', 'desc')
-				case 'byModifiedTime': return this.compareByTimestamp(a, b, 'mtime', 'asc')
-				case 'byModifiedTimeReverse': return this.compareByTimestamp(a, b, 'mtime', 'desc')
-				case 'byName':
-				default: return this.compareByName(a, b)
-			}
-		})
-	}
-
 	private compareByName(a: TAbstractFile, b: TAbstractFile) {
 		return collator.compare(a.name, b.name)
 	}
@@ -192,25 +297,75 @@ export class OrderManager {
 		return direction === 'asc' ? aTimestamp - bTimestamp : bTimestamp - aTimestamp
 	}
 
-	private persistAndLog(message: string) {
-		void this.plugin.saveSettings()
-		this.log(message, structuredClone(this.plugin.settings.items))
+	private persistAndLog(message: string, changedFolderPaths?: string[]) {
+		const plugin = this.plugin
+
+		if (plugin.settings.storageMode === 'per-folder' && changedFolderPaths && changedFolderPaths.length > 0) {
+			const uniquePaths = [...new Set(changedFolderPaths)]
+			for (const folderPath of uniquePaths) {
+				const folderSettings = plugin.settings.items[folderPath] as FolderSettings | undefined
+				if (!folderSettings) continue
+				void plugin.saveFolderState(folderPath, {
+					version: 1,
+					order: folderSettings.customOrder,
+					hidden: this.collectHiddenNames(folderPath),
+					pinned: this.collectPinnedNames(folderPath),
+					sortMode: folderSettings.sortOrder,
+				})
+			}
+			void plugin.saveSettings()
+			this.log(message, structuredClone(plugin.settings.items))
+			return
+		}
+
+		void plugin.saveSettings()
+		this.log(message, structuredClone(plugin.settings.items))
 	}
 
-	private persistCreateDeleteChange(message: string) {
+	private persistCreateDeleteChange(message: string, changedFolderPath?: string) {
 		if (!this.plugin.settings.persistOrderOnCreateDelete) {
 			this.log(message, structuredClone(this.plugin.settings.items))
 			return this.log('Skipping data.json update')
 		}
 
-		this.persistAndLog(message)
+		if (this.plugin.settings.storageMode === 'per-folder' && changedFolderPath) {
+			const folderSettings = this.plugin.settings.items[changedFolderPath] as FolderSettings | undefined
+			if (folderSettings) {
+				void this.plugin.saveFolderState(changedFolderPath, {
+					version: 1,
+					order: folderSettings.customOrder,
+					hidden: this.collectHiddenNames(changedFolderPath),
+					pinned: this.collectPinnedNames(changedFolderPath),
+					sortMode: folderSettings.sortOrder,
+				})
+			}
+			void this.plugin.saveSettings()
+			this.log(message, structuredClone(this.plugin.settings.items))
+			return
+		}
+
+		this.persistAndLog(message, changedFolderPath ? [changedFolderPath] : undefined)
 	}
 
-	private getName(path: string) {
-		return path.substring(path.lastIndexOf('/') + 1)
+	private collectHiddenNames(folderPath: string): string[] {
+		const items = this.plugin.settings.items
+		const hidden: string[] = []
+		for (const [path, item] of Object.entries(items)) {
+			if (isDirectChild(path, folderPath) && item.isHidden) {
+				hidden.push(getName(path))
+			}
+		}
+		return hidden
 	}
 
-	private getParentPath(path: string) {
-		return path.substring(0, path.lastIndexOf('/')) || '/'
+	private collectPinnedNames(folderPath: string): string[] {
+		const items = this.plugin.settings.items
+		const pinned: string[] = []
+		for (const [path, item] of Object.entries(items)) {
+			if (isDirectChild(path, folderPath) && item.isPinned) {
+				pinned.push(getName(path))
+			}
+		}
+		return pinned
 	}
 }

--- a/src/core/patcher.ts
+++ b/src/core/patcher.ts
@@ -23,13 +23,21 @@ export class Patcher {
 		const originalGetSortedFolderItems = explorerProto.getSortedFolderItems
 
 		explorerProto.getSortedFolderItems = function (folder) {
-			const origSorted = originalGetSortedFolderItems.call(this, folder)
-			const folderSettings = plugin.settings.items[folder.path] as FolderSettings
-			return plugin.orderManager.getSortedItems(folderSettings, origSorted)
+			let items = originalGetSortedFolderItems.call(this, folder)
+
+			// Per-folder mode: filter out metadata files from the tree
+			if (plugin.settings.storageMode === 'per-folder') {
+				const metaFilename = plugin.settings.folderMetadataFilename
+				items = items.filter(item => item.file.name !== metaFilename)
+			}
+
+			const folderSettings = plugin.settings.items[folder.path] as FolderSettings | undefined
+			if (!folderSettings) return items
+			return plugin.orderManager.getSortedItems(folderSettings, items)
 		}
 
 		this.unpatchExplorer = () => explorerProto.getSortedFolderItems = originalGetSortedFolderItems
-		this.log('Explorer patched')
+		this.log('Explorer patched' + (plugin.settings.storageMode === 'per-folder' ? ' (metadata filtered)' : ''))
 	}
 
 	patchMenu() {
@@ -44,7 +52,12 @@ export class Patcher {
 			if (triggerEl.getAttribute('aria-label') !== sortButtonLabel || !triggerEl.classList.contains('nav-action-button'))
 				return originalShowAtMouseEvent.call(this, evt)
 
-			const folderSettings = plugin.settings.items[ROOT_PATH] as FolderSettings
+			const folderSettings = (plugin.settings.items[ROOT_PATH] ?? {
+				customOrder: [],
+				sortOrder: 'custom',
+				isPinned: false,
+				isHidden: false,
+			}) as FolderSettings
 			const customMenu = populateSortMenu(new Menu(), folderSettings.sortOrder, plugin, ROOT_PATH, folderSettings)
 				.addItem(item => item.setTitle('Show hidden')
 					.setChecked(plugin.settings.showHidden)

--- a/src/core/storage/global-data-storage.ts
+++ b/src/core/storage/global-data-storage.ts
@@ -39,6 +39,7 @@ export class GlobalDataStorage implements FlexplorerStorage {
 		if (typeof settings.newItemPlacement === 'string') s.newItemPlacement = settings.newItemPlacement as never
 		if (typeof settings.persistOrderOnCreateDelete === 'boolean') s.persistOrderOnCreateDelete = settings.persistOrderOnCreateDelete
 		if (typeof settings.debugMode === 'boolean') s.debugMode = settings.debugMode
+		if (typeof settings.showCommandsInPalette === 'boolean') s.showCommandsInPalette = settings.showCommandsInPalette
 		await this.plugin.saveData(this.plugin.settings)
 	}
 

--- a/src/core/storage/global-data-storage.ts
+++ b/src/core/storage/global-data-storage.ts
@@ -1,0 +1,267 @@
+import { Notice } from 'obsidian'
+import type { FlexplorerPlugin } from '@/plugin'
+import { initLog } from '@/utils'
+import { emptyFolderState, serialiseFolderState, getMetadataPath, getName, childPrefix, isDirectChild } from './path-utils'
+import type { FolderState, FlexplorerStorage, MigrationResult, ReverseMigrationResult, ValidationResult } from './types'
+import type { ItemSettings } from '@/types'
+
+/**
+ * GlobalDataStorage – the original storage backend.
+ *
+ * Keeps **everything** inside a single `data.json` (via Obsidian's
+ * `loadData`/`saveData`). This is the default mode and is 100 %
+ * backward-compatible with the pre-refactor Flexplorer.
+ *
+ * To satisfy the {@link FlexplorerStorage} contract it translates
+ * between the flat `items` record and per-folder {@link FolderState}.
+ */
+export class GlobalDataStorage implements FlexplorerStorage {
+	private readonly log = initLog('GLOBAL-STORAGE', '#88ccff')
+
+	constructor(private readonly plugin: FlexplorerPlugin) {}
+
+	// ── Global settings ──────────────────────────────────────────────
+
+	async loadGlobalSettings(): Promise<Record<string, unknown>> {
+		const s = this.plugin.settings
+		return {
+			storageMode: 'global' as const,
+			showHidden: s.showHidden,
+			newItemPlacement: s.newItemPlacement,
+			persistOrderOnCreateDelete: s.persistOrderOnCreateDelete,
+			debugMode: s.debugMode,
+		}
+	}
+
+	async saveGlobalSettings(settings: Record<string, unknown>): Promise<void> {
+		const s = this.plugin.settings
+		if (typeof settings.showHidden === 'boolean') s.showHidden = settings.showHidden
+		if (typeof settings.newItemPlacement === 'string') s.newItemPlacement = settings.newItemPlacement as never
+		if (typeof settings.persistOrderOnCreateDelete === 'boolean') s.persistOrderOnCreateDelete = settings.persistOrderOnCreateDelete
+		if (typeof settings.debugMode === 'boolean') s.debugMode = settings.debugMode
+		await this.plugin.saveData(this.plugin.settings)
+	}
+
+	// ── Per-folder state ─────────────────────────────────────────────
+
+	async loadFolderState(folderPath: string): Promise<FolderState | null> {
+		const folderSettings = this.plugin.settings.items[folderPath] as { customOrder?: string[]; sortOrder?: string } | undefined
+		if (!folderSettings) return emptyFolderState()
+
+		const order = folderSettings.customOrder ?? []
+		const hidden = this.findHiddenInFolder(folderPath)
+		const pinned = this.findPinnedInFolder(folderPath)
+
+		return {
+			version: 1,
+			order,
+			hidden,
+			pinned,
+			sortMode: folderSettings.sortOrder as never,
+		}
+	}
+
+	async saveFolderState(folderPath: string, state: FolderState): Promise<void> {
+		const items = this.plugin.settings.items
+		const existing = items[folderPath]
+
+		items[folderPath] = {
+			...(existing as Record<string, unknown> ?? {}),
+			customOrder: state.order,
+			sortOrder: state.sortMode ?? 'custom',
+		} as ItemSettings
+
+		// Update individual item entries
+		const prefix = childPrefix(folderPath)
+		for (const name of state.hidden) {
+			const itemPath = prefix + name
+			const item = items[itemPath]
+			if (item) (item as Record<string, unknown>).isHidden = true
+		}
+		for (const name of state.pinned) {
+			const itemPath = prefix + name
+			const item = items[itemPath]
+			if (item) (item as Record<string, unknown>).isPinned = true
+		}
+
+		await this.plugin.saveData(this.plugin.settings)
+	}
+
+	async deleteFolderState(folderPath: string): Promise<void> {
+		const items = this.plugin.settings.items
+		delete items[folderPath]
+
+		// Delete all direct children' item settings
+		for (const key of Object.keys(items)) {
+			if (isDirectChild(key, folderPath)) {
+				delete items[key]
+			}
+		}
+
+		await this.plugin.saveData(this.plugin.settings)
+	}
+
+	async renameFolderState(oldFolderPath: string, newFolderPath: string): Promise<void> {
+		const state = await this.loadFolderState(oldFolderPath)
+		if (!state) return
+		await this.deleteFolderState(oldFolderPath)
+		await this.saveFolderState(newFolderPath, state)
+	}
+
+	// ── Bulk / lifecycle ─────────────────────────────────────────────
+
+	async enumerateFoldersWithState(): Promise<string[]> {
+		const items = this.plugin.settings.items
+		return Object.keys(items).filter(k => {
+			const v = items[k]
+			return typeof (v as Record<string, unknown>).customOrder === 'object' || typeof (v as Record<string, unknown>).sortOrder === 'string'
+		})
+	}
+
+	async loadAllFolderStates(): Promise<Map<string, FolderState>> {
+		const map = new Map<string, FolderState>()
+		const folderPaths = await this.enumerateFoldersWithState()
+		for (const fp of folderPaths) {
+			const state = await this.loadFolderState(fp)
+			if (state) map.set(fp, state)
+		}
+		return map
+	}
+
+	async flushPendingWrites(): Promise<void> {
+		// GlobalDataStorage writes synchronously through saveSettings → saveData.
+		// Nothing to flush.
+	}
+
+	// ── Migration helpers ────────────────────────────────────────────
+
+	async migrateToPerFolder(
+		filename: string,
+		onProgress?: (msg: string) => void,
+	): Promise<MigrationResult> {
+		const result: MigrationResult = {
+			foldersCreated: 0,
+			filesCreated: 0,
+			conflicts: [],
+			staleEntries: [],
+			backupPath: '',
+		}
+
+		const adapter = this.plugin.app.vault.adapter
+		const allStates = await this.loadAllFolderStates()
+
+		// Create backup
+		const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+		const backupPath = `${this.plugin.manifest.dir ?? '.obsidian/plugins/flexplorer'}/data.pre-per-folder-migration-${ts}.json`
+		result.backupPath = backupPath
+
+		await adapter.write(backupPath, JSON.stringify(this.plugin.settings, null, 2))
+		onProgress?.(`Backup created at ${backupPath}`)
+
+		for (const [folderPath, state] of allStates) {
+			const metaPath = getMetadataPath(folderPath, filename)
+			onProgress?.(`Processing ${metaPath}`)
+
+			const exists = await adapter.exists(metaPath)
+			if (exists) {
+				result.conflicts.push(metaPath)
+				// Read existing and merge
+				try {
+					const existingRaw = await adapter.read(metaPath)
+					const existing = JSON.parse(existingRaw) as FolderState
+					state.order = [...new Set([...existing.order, ...state.order])]
+					state.hidden = [...new Set([...existing.hidden, ...state.hidden])]
+					state.pinned = [...new Set([...existing.pinned, ...state.pinned])]
+				} catch {
+					// Leave our version as-is
+				}
+				onProgress?.(`  Merged with existing ${metaPath}`)
+			}
+
+			try {
+				await adapter.write(metaPath, serialiseFolderState(state))
+				result.foldersCreated++
+				result.filesCreated++
+			} catch (e) {
+				this.log('Failed to write', metaPath, e)
+				result.conflicts.push(`${metaPath} (write failed)`)
+			}
+		}
+
+		// Detect stale entries (items pointing to non-existent files)
+		for (const path of Object.keys(this.plugin.settings.items)) {
+			if (!this.plugin.app.vault.getAbstractFileByPath(path)) {
+				result.staleEntries.push(path)
+			}
+		}
+
+		onProgress?.(`Migration complete: ${result.foldersCreated} folders, ${result.filesCreated} files, ${result.conflicts.length} conflicts`)
+		return result
+	}
+
+	async validateMetadataFiles(filename: string): Promise<ValidationResult> {
+		const result: ValidationResult = {
+			totalFiles: 0,
+			validFiles: 0,
+			invalidFiles: [],
+			unknownVersionFiles: [],
+			staleReferences: [],
+		}
+
+		const adapter = this.plugin.app.vault.adapter
+		const folderPaths = await this.enumerateFoldersWithState()
+
+		for (const fp of folderPaths) {
+			result.totalFiles++
+			const state = await this.loadFolderState(fp)
+			if (!state) {
+				result.invalidFiles.push(fp)
+				continue
+			}
+			if (state.version !== 1) {
+				result.unknownVersionFiles.push(fp)
+				continue
+			}
+			result.validFiles++
+
+			// Check stale references
+			const folder = this.plugin.app.vault.getFolderByPath(fp)
+			if (!folder) {
+				result.staleReferences.push(fp)
+				continue
+			}
+			const existingNames = new Set(folder.children.map(c => c.name))
+			for (const name of [...state.order, ...state.hidden, ...state.pinned]) {
+				if (!existingNames.has(name)) {
+					result.staleReferences.push(`${fp}/${name}`)
+				}
+			}
+		}
+
+		return result
+	}
+
+	// ── Internal helpers ─────────────────────────────────────────────
+
+	private findHiddenInFolder(folderPath: string): string[] {
+		const items = this.plugin.settings.items
+		const hidden: string[] = []
+		for (const [path, item] of Object.entries(items)) {
+			if (isDirectChild(path, folderPath) && (item as Record<string, unknown>).isHidden) {
+				hidden.push(getName(path))
+			}
+		}
+		return hidden
+	}
+
+	private findPinnedInFolder(folderPath: string): string[] {
+		const items = this.plugin.settings.items
+		const pinned: string[] = []
+		for (const [path, item] of Object.entries(items)) {
+			if (isDirectChild(path, folderPath) && (item as Record<string, unknown>).isPinned) {
+				pinned.push(getName(path))
+			}
+		}
+		return pinned
+	}
+}

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -1,0 +1,16 @@
+export type { FlexplorerStorage, FolderState, MigrationResult, ReverseMigrationResult, ValidationResult, MigrationPreview, PendingSave } from './types'
+export { GlobalDataStorage } from './global-data-storage'
+export { PerFolderFileStorage } from './per-folder-file-storage'
+export {
+	getMetadataPath,
+	getParentPath,
+	getName,
+	validateMetadataFilename,
+	serialiseFolderState,
+	emptyFolderState,
+	isFolderStateEmpty,
+	pruneStaleReferences,
+	childPrefix,
+	isDirectChild,
+	DEFAULT_METADATA_FILENAME,
+} from './path-utils'

--- a/src/core/storage/path-utils.ts
+++ b/src/core/storage/path-utils.ts
@@ -1,0 +1,168 @@
+import type { FolderState } from './types'
+
+/** The metadata filename used in per-folder storage mode. */
+export const DEFAULT_METADATA_FILENAME = '.flexplorer.json'
+
+/**
+ * Build the metadata file path for a given folder.
+ *
+ * Handles the vault root specially: when `folderPath` is empty or `'/'`,
+ * the metadata file sits at the vault root, not at `/.flexplorer.json`.
+ *
+ * Examples:
+ * ```
+ * getMetadataPath('')            → '.flexplorer.json'
+ * getMetadataPath('/')           → '.flexplorer.json'
+ * getMetadataPath('Documentation') → 'Documentation/.flexplorer.json'
+ * getMetadataPath('A/B/C')       → 'A/B/C/.flexplorer.json'
+ * ```
+ */
+export function getMetadataPath(folderPath: string, filename = DEFAULT_METADATA_FILENAME): string {
+	const normalised = folderPath === '/' ? '' : folderPath.replace(/^\/+|\/+$/g, '')
+	return normalised ? `${normalised}/${filename}` : filename
+}
+
+/**
+ * Extract the parent folder path from an absolute item path.
+ * Returns `'/'` for top-level items to match Obsidian's root convention.
+ *
+ * Examples:
+ * ```
+ * getParentPath('Documentation/Introduction.md') → 'Documentation'
+ * getParentPath('Introduction.md')              → '/'
+ * getParentPath('/')                             → '/'
+ * ```
+ */
+export function getParentPath(itemPath: string): string {
+	if (itemPath === '/') return '/'
+	const idx = itemPath.lastIndexOf('/')
+	return idx === -1 ? '/' : itemPath.slice(0, idx)
+}
+
+/**
+ * Extract the leaf name (file or folder) from an absolute path.
+ *
+ * Examples:
+ * ```
+ * getName('Documentation/Introduction.md') → 'Introduction.md'
+ * getName('Introduction.md')              → 'Introduction.md'
+ * getName('/')                             → ''
+ * ```
+ */
+export function getName(itemPath: string): string {
+	const idx = itemPath.lastIndexOf('/')
+	return idx === -1 ? itemPath : itemPath.slice(idx + 1)
+}
+
+/**
+ * Validate a metadata filename candidate.
+ * Returns an error message string, or `null` when valid.
+ */
+export function validateMetadataFilename(name: string): string | null {
+	const trimmed = name.trim()
+
+	if (!trimmed) return 'Filename must not be empty'
+	if (trimmed.includes('/') || trimmed.includes('\\')) return 'Filename must not contain / or \\'
+	if (trimmed === '.' || trimmed === '..') return 'Filename must not be "." or ".."'
+	if (trimmed.length > 255) return 'Filename is too long (max 255 characters)'
+
+	return null
+}
+
+/**
+ * Serialise a FolderState for writing.
+ * Always produces stable, deterministic JSON:
+ * - keys in a fixed order (version, order, hidden, pinned, ...)
+ * - formatted with 2-space indent
+ * - trailing newline
+ */
+export function serialiseFolderState(state: FolderState): string {
+	const ordered: Record<string, unknown> = {
+		version: state.version,
+		order: state.order,
+		hidden: state.hidden,
+		pinned: state.pinned,
+	}
+
+	if (state.sortMode && state.sortMode !== 'custom') {
+		ordered.sortMode = state.sortMode
+	}
+
+	// Include any unrecognised extension fields (sorted for stability)
+	const known = new Set(['version', 'order', 'hidden', 'pinned', 'sortMode'])
+	const extra = Object.keys(state)
+		.filter(k => !known.has(k))
+		.sort()
+
+	for (const key of extra) {
+		ordered[key] = state[key]
+	}
+
+	return JSON.stringify(ordered, null, 2) + '\n'
+}
+
+/** Create an empty (default) folder state. */
+export function emptyFolderState(): FolderState {
+	return {
+		version: 1,
+		order: [],
+		hidden: [],
+		pinned: [],
+	}
+}
+
+/** Check whether a folder state is effectively empty (all arrays empty, no extra fields). */
+export function isFolderStateEmpty(state: FolderState): boolean {
+	return state.version === 1
+		&& state.order.length === 0
+		&& state.hidden.length === 0
+		&& state.pinned.length === 0
+		&& (!state.sortMode || state.sortMode === 'custom')
+		&& Object.keys(state).filter(k => !['version', 'order', 'hidden', 'pinned', 'sortMode'].includes(k)).length === 0
+}
+
+/**
+ * Remove references to items not present in `existingNames`.
+ * Returns a new state without mutating the original.
+ */
+export function pruneStaleReferences(state: FolderState, existingNames: Set<string>): FolderState {
+	return {
+		...state,
+		order: state.order.filter(n => existingNames.has(n)),
+		hidden: state.hidden.filter(n => existingNames.has(n)),
+		pinned: state.pinned.filter(n => existingNames.has(n)),
+	}
+}
+
+/**
+ * Build the item-path prefix for children of a given folder.
+ *
+ * When `folderPath` is the root (`'/'`), children are at the vault root
+ * so the prefix is empty.  Otherwise it is `folderPath + '/'`.
+ *
+ * Examples:
+ * ```
+ * childPrefix('/')              → ''
+ * childPrefix('Documentation')   → 'Documentation/'
+ * childPrefix('A/B/C')          → 'A/B/C/'
+ * ```
+ */
+export function childPrefix(folderPath: string): string {
+	return folderPath === '/' ? '' : `${folderPath}/`
+}
+
+/**
+ * Check whether `childPath` is a direct child of the folder at `folderPath`.
+ *
+ * Examples:
+ * ```
+ * isDirectChild('Readme.md', '/')              → true
+ * isDirectChild('/')                            → fallsú
+ * isDirectChild('Doc/Readme.md', 'Doc')         → true
+ * isDirectChild('Doc/Sub/Readme.md', 'Doc')     → false
+ * ```
+ */
+export function isDirectChild(childPath: string, folderPath: string): boolean {
+	if (childPath === folderPath) return false
+	return getParentPath(childPath) === folderPath
+}

--- a/src/core/storage/per-folder-file-storage.ts
+++ b/src/core/storage/per-folder-file-storage.ts
@@ -1,0 +1,598 @@
+import { Notice } from 'obsidian'
+import type { FlexplorerPlugin } from '@/plugin'
+import { initLog } from '@/utils'
+import {
+	emptyFolderState,
+	getMetadataPath,
+	getName,
+	isFolderStateEmpty,
+	serialiseFolderState,
+	validateMetadataFilename,
+	childPrefix,
+} from './path-utils'
+import type {
+	FolderState,
+	FlexplorerStorage,
+	MigrationResult,
+	ReverseMigrationResult,
+	ValidationResult,
+} from './types'
+
+const CURRENT_VERSION = 1
+const SAVE_DEBOUNCE_MS = 300
+
+/**
+ * PerFolderFileStorage – the new Git-friendly storage backend.
+ *
+ * Stores each folder's ordering, hidden, and pinned state in a dedicated
+ * metadata file (`.flexplorer.json` by default) inside that folder.
+ * Global settings remain in the plugin's `data.json`.
+ *
+ * Features:
+ * - Lazy-loading with in-memory cache
+ * - Per-folder debounced writes (independent timers)
+ * - Self-written-path tracking to survive Obsidian's modify events
+ * - External-change detection to avoid stale-write races
+ * - Atomic read-then-write for conflict reduction
+ */
+export class PerFolderFileStorage implements FlexplorerStorage {
+	private readonly log = initLog('PER-FOLDER-STORAGE', '#44ddbb')
+
+	/** Folder path → cached FolderState (lazy-populated). */
+	private readonly cache = new Map<string, FolderState>()
+
+	/** Folder path → debounce timer. */
+	private readonly saveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+	/** Pending write promises, one per folder. */
+	private readonly pendingWrites = new Map<string, Promise<void>>()
+
+	/** Absolute paths (vault-relative) we wrote ourselves this session. */
+	private readonly selfWrittenPaths = new Set<string>()
+
+	/** The content we last wrote for a given metadata path — for external-change detection. */
+	private readonly lastWrittenContent = new Map<string, string>()
+
+	private _metadataFilename = '.flexplorer.json'
+
+	constructor(private readonly plugin: FlexplorerPlugin) {}
+
+	get metadataFilename(): string {
+		return this._metadataFilename
+	}
+
+	set metadataFilename(name: string) {
+		const err = validateMetadataFilename(name)
+		if (err) throw new Error(err)
+		if (this._metadataFilename !== name) {
+			this.clearCache()
+			this._metadataFilename = name
+		}
+	}
+
+	// ── Global settings ──────────────────────────────────────────────
+
+	async loadGlobalSettings(): Promise<Record<string, unknown>> {
+		const s = this.plugin.settings
+		return {
+			storageMode: 'per-folder' as const,
+			folderMetadataFilename: this._metadataFilename,
+			showHidden: s.showHidden,
+			newItemPlacement: s.newItemPlacement,
+			persistOrderOnCreateDelete: s.persistOrderOnCreateDelete,
+			debugMode: s.debugMode,
+		}
+	}
+
+	async saveGlobalSettings(settings: Record<string, unknown>): Promise<void> {
+		const s = this.plugin.settings
+		if (typeof settings.showHidden === 'boolean') s.showHidden = settings.showHidden
+		if (typeof settings.newItemPlacement === 'string') s.newItemPlacement = settings.newItemPlacement as never
+		if (typeof settings.persistOrderOnCreateDelete === 'boolean') s.persistOrderOnCreateDelete = settings.persistOrderOnCreateDelete
+		if (typeof settings.debugMode === 'boolean') s.debugMode = settings.debugMode
+		if (typeof settings.folderMetadataFilename === 'string') {
+			this.metadataFilename = settings.folderMetadataFilename
+		}
+
+		// Save only global settings to data.json, NOT items/pinnedFiles — those
+		// belong in .flexplorer.json in per-folder mode.
+		const globalData: Record<string, unknown> = {
+			storageMode: 'per-folder',
+			folderMetadataFilename: this._metadataFilename,
+			showHidden: s.showHidden,
+			newItemPlacement: s.newItemPlacement,
+			persistOrderOnCreateDelete: s.persistOrderOnCreateDelete,
+			debugMode: s.debugMode,
+		}
+		await this.plugin.saveData(globalData)
+	}
+
+	// ── Per-folder state ─────────────────────────────────────────────
+
+	async loadFolderState(folderPath: string): Promise<FolderState | null> {
+		// Normalize root path
+		const normalPath = folderPath || '/'
+		const cached = this.cache.get(normalPath)
+		if (cached !== undefined) return cached
+
+		const metaPath = getMetadataPath(normalPath, this._metadataFilename)
+		const adapter = this.plugin.app.vault.adapter
+
+		try {
+			const exists = await adapter.exists(metaPath)
+			if (!exists) {
+				this.cache.set(normalPath, emptyFolderState())
+				return emptyFolderState()
+			}
+
+			const raw = await adapter.read(metaPath)
+
+			if (this.selfWrittenPaths.has(metaPath)) {
+				this.selfWrittenPaths.delete(metaPath)
+			}
+
+			const parsed = this.parseFolderState(raw, metaPath)
+			if (parsed === null) {
+				this.cache.set(normalPath, emptyFolderState())
+				return null
+			}
+
+			this.cache.set(normalPath, parsed)
+			return parsed
+		} catch (e) {
+			this.log('Error reading metadata file:', metaPath, e)
+			this.cache.set(normalPath, emptyFolderState())
+			return null
+		}
+	}
+
+	async saveFolderState(folderPath: string, state: FolderState): Promise<void> {
+		this.cache.set(folderPath, { ...state })
+
+		const existing = this.saveTimers.get(folderPath)
+		if (existing) clearTimeout(existing)
+
+		return new Promise<void>(resolve => {
+			const timer = setTimeout(async () => {
+				try {
+					await this.writeFolderState(folderPath, state)
+				} finally {
+					this.saveTimers.delete(folderPath)
+					this.pendingWrites.delete(folderPath)
+					resolve()
+				}
+			}, SAVE_DEBOUNCE_MS)
+
+			this.saveTimers.set(folderPath, timer)
+
+			const prom = new Promise<void>(res => {
+				const origTimer = timer
+				const check = setInterval(() => {
+					if (this.saveTimers.get(folderPath) !== origTimer) {
+						clearInterval(check)
+						const current = this.pendingWrites.get(folderPath)
+						if (current) current.then(res).catch(res)
+						else res()
+					}
+				}, 50)
+			})
+			this.pendingWrites.set(folderPath, prom)
+		})
+	}
+
+	async deleteFolderState(folderPath: string): Promise<void> {
+		this.cache.delete(folderPath)
+		const timer = this.saveTimers.get(folderPath)
+		if (timer) {
+			clearTimeout(timer)
+			this.saveTimers.delete(folderPath)
+		}
+		this.pendingWrites.delete(folderPath)
+
+		const metaPath = getMetadataPath(folderPath, this._metadataFilename)
+		const adapter = this.plugin.app.vault.adapter
+		try {
+			if (await adapter.exists(metaPath)) {
+				selfWrittenAdd(this.selfWrittenPaths, metaPath)
+				await adapter.remove(metaPath)
+			}
+		} catch (e) {
+			this.log('Error deleting metadata file:', metaPath, e)
+		}
+	}
+
+	async renameFolderState(oldFolderPath: string, newFolderPath: string): Promise<void> {
+		const state = this.cache.get(oldFolderPath) ?? await this.loadFolderState(oldFolderPath)
+		if (state) {
+			this.cache.delete(oldFolderPath)
+			this.cache.set(newFolderPath, state)
+		}
+
+		const oldMeta = getMetadataPath(oldFolderPath, this._metadataFilename)
+		const newMeta = getMetadataPath(newFolderPath, this._metadataFilename)
+		const adapter = this.plugin.app.vault.adapter
+
+		try {
+			if (await adapter.exists(oldMeta)) {
+				selfWrittenAdd(this.selfWrittenPaths, oldMeta)
+				selfWrittenAdd(this.selfWrittenPaths, newMeta)
+				await adapter.rename(oldMeta, newMeta)
+			}
+		} catch (e) {
+			this.log('Error renaming metadata file:', oldMeta, '→', newMeta, e)
+		}
+	}
+
+	// ── Bulk / lifecycle ─────────────────────────────────────────────
+
+	async enumerateFoldersWithState(): Promise<string[]> {
+		const adapter = this.plugin.app.vault.adapter
+		const folders: string[] = []
+
+		try {
+			await this.collectFoldersWithMetadata('', folders, adapter)
+		} catch (e) {
+			this.log('Error enumerating folders:', e)
+		}
+
+		return folders
+	}
+
+	async loadAllFolderStates(): Promise<Map<string, FolderState>> {
+		const map = new Map<string, FolderState>()
+		const folders = await this.enumerateFoldersWithState()
+		for (const fp of folders) {
+			const state = await this.loadFolderState(fp)
+			if (state) map.set(fp, state)
+		}
+		return map
+	}
+
+	async flushPendingWrites(): Promise<void> {
+		// Execute all pending writes immediately (bypass debounce)
+		const pending = [...this.saveTimers.keys()]
+		for (const folderPath of pending) {
+			const timer = this.saveTimers.get(folderPath)
+			if (timer) clearTimeout(timer)
+			this.saveTimers.delete(folderPath)
+		}
+		this.pendingWrites.clear()
+
+		// Flush cache entries that were touched but not yet written
+		for (const [folderPath, state] of this.cache) {
+			if (state && !isFolderStateEmpty(state)) {
+				await this.writeFolderState(folderPath, state)
+			}
+		}
+	}
+
+	invalidateCache(folderPath: string): void {
+		this.cache.delete(folderPath)
+	}
+
+	clearCache(): void {
+		this.cache.clear()
+	}
+
+	markSelfWritten(metaPath: string): void {
+		selfWrittenAdd(this.selfWrittenPaths, metaPath)
+	}
+
+	isMetadataFile(vaultPath: string): boolean {
+		const filename = this._metadataFilename
+		return vaultPath === filename
+			|| vaultPath.endsWith(`/${filename}`)
+			|| vaultPath === `/${filename}`
+	}
+
+	async handleExternalModify(metaPath: string): Promise<void> {
+		const folderPath = this.metaPathToFolderPath(metaPath)
+		if (folderPath === undefined) return
+
+		if (this.selfWrittenPaths.has(metaPath)) {
+			this.selfWrittenPaths.delete(metaPath)
+			return
+		}
+
+		// If the user has pending (unsaved) changes for this folder, skip
+		// re-reading so their in-progress drag-and-drop is not wiped out.
+		// The next writeFolderState will merge external changes on save.
+		if (this.saveTimers.has(folderPath)) {
+			this.log('External change skipped — pending local changes for', folderPath)
+			return
+		}
+
+		this.log('External change detected:', metaPath)
+		this.cache.delete(folderPath)
+		await this.loadFolderState(folderPath)
+
+		this.plugin.sortExplorer()
+		this.plugin.explorerManager.syncIndicators()
+	}
+
+	/** Return the folder path (Obsidian convention: '/' for root) that owns a metadata path. */
+	private metaPathToFolderPath(metaPath: string): string | undefined {
+		const filename = this._metadataFilename
+		if (metaPath === filename) return '/'
+
+		const suffix = `/${filename}`
+		if (metaPath.endsWith(suffix)) {
+			const folder = metaPath.slice(0, -suffix.length)
+			return folder || '/'
+		}
+		return undefined
+	}
+
+	// ── Migration helpers ────────────────────────────────────────────
+
+	async validateMetadataFiles(): Promise<ValidationResult> {
+		const result: ValidationResult = {
+			totalFiles: 0,
+			validFiles: 0,
+			invalidFiles: [],
+			unknownVersionFiles: [],
+			staleReferences: [],
+		}
+
+		const adapter = this.plugin.app.vault.adapter
+		const folders = await this.enumerateFoldersWithState()
+
+		for (const fp of folders) {
+			result.totalFiles++
+			const metaPath = getMetadataPath(fp, this._metadataFilename)
+			try {
+				const raw = await adapter.read(metaPath)
+				const parsed = this.parseFolderState(raw, metaPath)
+				if (parsed === null) {
+					result.invalidFiles.push(metaPath)
+					continue
+				}
+				if (parsed.version !== CURRENT_VERSION) {
+					result.unknownVersionFiles.push(metaPath)
+					continue
+				}
+				result.validFiles++
+
+				const folder = this.plugin.app.vault.getFolderByPath(fp)
+				if (!folder) {
+					result.staleReferences.push(fp)
+					continue
+				}
+				const existingNames = new Set(folder.children.map(c => c.name))
+				for (const name of [...parsed.order, ...parsed.hidden, ...parsed.pinned]) {
+					if (!existingNames.has(name)) {
+						result.staleReferences.push(`${fp}/${name}`)
+					}
+				}
+			} catch (e) {
+				result.invalidFiles.push(metaPath)
+			}
+		}
+
+		return result
+	}
+
+	/**
+	 * Convenience: build up `items` and `pinnedFiles` from folder states.
+	 * Used by the plugin after loading or migration.
+	 */
+	async rebuildFlatState(): Promise<{
+		items: Record<string, unknown>
+		pinnedFiles: string[]
+	}> {
+		const items: Record<string, unknown> = {}
+		const pinnedFiles: string[] = []
+		const allStates = await this.loadAllFolderStates()
+
+		for (const [folderPath, state] of allStates) {
+			const prefix = childPrefix(folderPath)
+
+			// Don't overwrite isPinned/isHidden set by parent folder's state
+			items[folderPath] = {
+				...(items[folderPath] as Record<string, unknown> ?? {}),
+				customOrder: state.order,
+				sortOrder: state.sortMode ?? 'custom',
+			}
+
+			for (const name of state.hidden) {
+				const path = prefix + name
+				const existing = items[path] ?? {}
+				items[path] = { ...(existing as Record<string, unknown>), isHidden: true }
+			}
+
+			for (const name of state.pinned) {
+				const path = prefix + name
+				const existing = items[path] ?? {}
+				items[path] = { ...(existing as Record<string, unknown>), isPinned: true }
+				if (!pinnedFiles.includes(path)) pinnedFiles.push(path)
+			}
+		}
+
+		// Ensure every vault folder has at least a default entry,
+		// so the patched getSortedFolderItems never gets undefined.
+		this.ensureAllFoldersInItems(items)
+
+		return { items, pinnedFiles }
+	}
+
+	/**
+	 * Walk the vault tree and create default entries for any folder
+	 * that doesn't have one yet.
+	 */
+	private ensureAllFoldersInItems(items: Record<string, unknown>): void {
+		const walk = (folderPath: string): void => {
+			if (!items[folderPath]) {
+				items[folderPath] = {
+					customOrder: [],
+					sortOrder: 'custom',
+				}
+			}
+			const folder = this.plugin.app.vault.getFolderByPath(folderPath === '/' ? '/' : folderPath)
+			if (!folder) return
+			for (const child of folder.children) {
+				if ('children' in child) {
+					walk(child.path)
+				}
+			}
+		}
+		walk('/')
+	}
+
+	// ── Private helpers ──────────────────────────────────────────────
+
+	private async writeFolderState(folderPath: string, state: FolderState): Promise<void> {
+		const metaPath = getMetadataPath(folderPath, this._metadataFilename)
+		const adapter = this.plugin.app.vault.adapter
+
+		// Variant B: delete the file when state is completely empty
+		if (isFolderStateEmpty(state)) {
+			try {
+				if (await adapter.exists(metaPath)) {
+					selfWrittenAdd(this.selfWrittenPaths, metaPath)
+					await adapter.remove(metaPath)
+				}
+			} catch (e) {
+				this.log('Error deleting empty metadata file:', metaPath, e)
+			}
+			this.lastWrittenContent.delete(metaPath)
+			return
+		}
+
+		// External-change guard: re-read the file before writing
+		try {
+			if (await adapter.exists(metaPath)) {
+				const currentRaw = await adapter.read(metaPath)
+				const lastWritten = this.lastWrittenContent.get(metaPath)
+
+				if (lastWritten !== undefined && currentRaw !== lastWritten) {
+					const externalState = this.parseFolderState(currentRaw, metaPath)
+					if (externalState !== null) {
+						const merged: FolderState = {
+							...state,
+							hidden: [...new Set([...externalState.hidden, ...state.hidden])],
+							pinned: [...new Set([...externalState.pinned, ...state.pinned])],
+						}
+
+						if (JSON.stringify(merged) !== JSON.stringify(state)) {
+							new Notice(
+								`Flexplorer detected external changes to ${metaPath} and merged them with your local changes.`,
+								5000,
+							)
+							this.log('Merged external changes for', metaPath)
+							state = merged
+						}
+					}
+				}
+			}
+		} catch {
+			// If re-reading fails, proceed with write anyway
+		}
+
+		const content = serialiseFolderState(state)
+
+		selfWrittenAdd(this.selfWrittenPaths, metaPath)
+		this.lastWrittenContent.set(metaPath, content)
+
+		try {
+			await adapter.write(metaPath, content)
+		} catch (e) {
+			this.log('Error writing metadata file:', metaPath, e)
+			throw e
+		}
+	}
+
+	private parseFolderState(raw: string, metaPath: string): FolderState | null {
+		let parsed: Record<string, unknown>
+		try {
+			parsed = JSON.parse(raw)
+		} catch {
+			new Notice(
+				`Flexplorer could not read ${metaPath}. The file contains invalid JSON. Default sorting is used for this folder.`,
+				5000,
+			)
+			this.log('Invalid JSON in', metaPath)
+			return null
+		}
+
+		if (typeof parsed !== 'object' || parsed === null) {
+			new Notice(`Flexplorer: ${metaPath} is not a valid JSON object.`)
+			return null
+		}
+
+		const version = typeof parsed.version === 'number' ? parsed.version : 1
+		if (version !== CURRENT_VERSION) {
+			new Notice(
+				`Flexplorer: ${metaPath} has version ${version}, but only version ${CURRENT_VERSION} is supported. Default sorting used for this folder.`,
+				5000,
+			)
+			this.log('Unknown version', version, 'in', metaPath)
+			return null
+		}
+
+		const state: FolderState = {
+			version,
+			order: Array.isArray(parsed.order) ? parsed.order.filter((e): e is string => typeof e === 'string') : [],
+			hidden: Array.isArray(parsed.hidden) ? parsed.hidden.filter((e): e is string => typeof e === 'string') : [],
+			pinned: Array.isArray(parsed.pinned) ? parsed.pinned.filter((e): e is string => typeof e === 'string') : [],
+		}
+
+		if (typeof parsed.sortMode === 'string') {
+			state.sortMode = parsed.sortMode as never
+		}
+
+		const known = new Set(['version', 'order', 'hidden', 'pinned', 'sortMode'])
+		for (const [key, value] of Object.entries(parsed)) {
+			if (!known.has(key)) {
+				state[key] = value
+			}
+		}
+
+		return state
+	}
+
+	private async collectFoldersWithMetadata(
+		prefix: string,
+		acc: string[],
+		adapter: { list: (path: string) => Promise<{ files: string[]; folders: string[] }>; exists: (path: string) => Promise<boolean> },
+	): Promise<void> {
+		const filename = this._metadataFilename
+
+		try {
+			const listing = await adapter.list(prefix)
+
+			// Check the current folder's own metadata file (not just subfolders)
+			// For root (prefix=''), this checks '.flexplorer.json'
+			const ownMeta = prefix ? `${prefix}/${filename}` : filename
+			try {
+				if (await adapter.exists(ownMeta)) {
+					acc.push(prefix || '/')
+				}
+			} catch {}
+
+			for (const folderPath of listing.folders) {
+				const metaPath = `${folderPath}/${filename}`
+				try {
+					if (await adapter.exists(metaPath)) {
+						const normalised = folderPath.replace(/^\/+|\/+$/g, '')
+						acc.push(normalised)
+					}
+				} catch {
+					// Skip inaccessible folders
+				}
+				await this.collectFoldersWithMetadata(folderPath, acc, adapter)
+			}
+		} catch {
+			// Prefix may not exist (empty root etc.)
+		}
+	}
+}
+
+/**
+ * Thread-safe-ish helper: add a path to the self-written set,
+ * then schedule its removal after a short delay to account for
+ * Obsidian's event processing latency.
+ */
+function selfWrittenAdd(set: Set<string>, path: string): void {
+	set.add(path)
+	setTimeout(() => set.delete(path), 2000)
+}

--- a/src/core/storage/per-folder-file-storage.ts
+++ b/src/core/storage/per-folder-file-storage.ts
@@ -90,6 +90,7 @@ export class PerFolderFileStorage implements FlexplorerStorage {
 		if (typeof settings.newItemPlacement === 'string') s.newItemPlacement = settings.newItemPlacement as never
 		if (typeof settings.persistOrderOnCreateDelete === 'boolean') s.persistOrderOnCreateDelete = settings.persistOrderOnCreateDelete
 		if (typeof settings.debugMode === 'boolean') s.debugMode = settings.debugMode
+		if (typeof settings.showCommandsInPalette === 'boolean') s.showCommandsInPalette = settings.showCommandsInPalette
 		if (typeof settings.folderMetadataFilename === 'string') {
 			this.metadataFilename = settings.folderMetadataFilename
 		}
@@ -103,6 +104,7 @@ export class PerFolderFileStorage implements FlexplorerStorage {
 			newItemPlacement: s.newItemPlacement,
 			persistOrderOnCreateDelete: s.persistOrderOnCreateDelete,
 			debugMode: s.debugMode,
+			showCommandsInPalette: s.showCommandsInPalette,
 		}
 		await this.plugin.saveData(globalData)
 	}

--- a/src/core/storage/types.ts
+++ b/src/core/storage/types.ts
@@ -1,0 +1,135 @@
+import type { SortOrder } from '@/types'
+
+/**
+ * Versioned state for a single folder, stored in `.flexplorer.json`.
+ */
+export interface FolderState {
+	version: number
+	/** Relative names of immediate children in manual order. */
+	order: string[]
+	/** Relative names of hidden immediate children. */
+	hidden: string[]
+	/** Relative names of pinned immediate children. */
+	pinned: string[]
+	/**
+	 * Per-folder sort mode. `undefined` (or absent) means "inherit global
+	 * default" which is `'custom'` in the current Flexplorer model.
+	 */
+	sortMode?: SortOrder
+	/**
+	 * Extension slot – parsers MUST ignore unknown fields within the same
+	 * major version so future fields (e.g. `groups`) do not break older
+	 * plugin versions.
+	 */
+	[unknownField: string]: unknown
+}
+
+/**
+ * Storage backend contract.
+ *
+ * Every backend MUST:
+ * - be stateless from the caller's perspective (own caching internally);
+ * - return a full {@link FolderState} for every folder that exists on disk,
+ *   even when no metadata file has been created yet (empty defaults);
+ * - tolerate concurrent calls on different folder paths.
+ */
+export interface FlexplorerStorage {
+	// ── Global settings ──────────────────────────────────────────────
+
+	/** Load the global (non-folder-specific) settings map. */
+	loadGlobalSettings(): Promise<Record<string, unknown>>
+
+	/** Persist the global settings map. */
+	saveGlobalSettings(settings: Record<string, unknown>): Promise<void>
+
+	// ── Per-folder state ─────────────────────────────────────────────
+
+	/**
+	 * Return the state for `folderPath`.
+	 *
+	 * Returns a default empty state when no metadata file exists yet.
+	 * Returns `null` when the file is corrupt or has an unknown version
+	 * (caller decides fallback behaviour).
+	 */
+	loadFolderState(folderPath: string): Promise<FolderState | null>
+
+	/** Persist `state` for `folderPath`. Creates parent directories if needed. */
+	saveFolderState(folderPath: string, state: FolderState): Promise<void>
+
+	/** Delete the metadata file for a folder. No-op if absent. */
+	deleteFolderState(folderPath: string): Promise<void>
+
+	/**
+	 * Rename a folder's stored state (e.g. after the folder itself was
+	 * moved/renamed). Default implementation calls
+	 * {@link loadFolderState old} → {@link saveFolderState new} → {@link deleteFolderState old}.
+	 * Override for atomic renames when the backend supports it.
+	 */
+	renameFolderState(oldFolderPath: string, newFolderPath: string): Promise<void>
+
+	// ── Bulk / lifecycle ─────────────────────────────────────────────
+
+	/**
+	 * Scan the vault and return every folder that has a metadata file.
+	 * Used during migration and validation.
+	 * `undefined` means the backend cannot enumerate (always returns
+	 * everything in {@link loadGlobalSettings}).
+	 */
+	enumerateFoldersWithState?(): Promise<string[]>
+
+	/**
+	 * Load every folder state that exists on disk.
+	 * Used during migration and reverse-migration.
+	 */
+	loadAllFolderStates(): Promise<Map<string, FolderState>>
+
+	/** Flush any pending/throttled writes and settle the underlying I/O. */
+	flushPendingWrites(): Promise<void>
+}
+
+/** Internal state that bridges between the flat `items` record and per-folder files. */
+export interface FolderStateData {
+	folderPath: string
+	state: FolderState
+}
+
+/** Result of the forward migration (data.json → per-folder). */
+export interface MigrationResult {
+	foldersCreated: number
+	filesCreated: number
+	conflicts: string[]
+	staleEntries: string[]
+	backupPath: string
+}
+
+/** Result of the reverse migration (per-folder → data.json). */
+export interface ReverseMigrationResult {
+	foldersProcessed: number
+	totalItems: number
+	backupPath: string
+}
+
+/** Result of a validation run. */
+export interface ValidationResult {
+	totalFiles: number
+	validFiles: number
+	invalidFiles: string[]
+	unknownVersionFiles: string[]
+	staleReferences: string[]
+}
+
+/** Options passed to dry-run preview. */
+export interface MigrationPreview {
+	foldersAffected: number
+	filesToCreate: number
+	existingFiles: string[]
+	staleEntries: string[]
+	globalKeysPreserved: string[]
+}
+
+/** Debounced save entry for a single folder. */
+export interface PendingSave {
+	promise: Promise<void>
+	resolve: () => void
+	timer: ReturnType<typeof setTimeout> | undefined
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFolder } from 'obsidian'
+import { Notice, Plugin, TFolder } from 'obsidian'
 import type { FileExplorerView } from 'obsidian-typings'
 
 import { DndEngine } from '@/core/dnd-engine'
@@ -8,9 +8,24 @@ import { Patcher } from '@/core/patcher'
 import { SettingsTab } from '@/ui/settings'
 import { populateSortMenu } from '@/ui/menu'
 import { initLog, logger } from '@/utils'
-import type { FolderSettings, Settings } from '@/types'
+import type { FolderSettings, ItemSettings, Settings, StorageMode } from '@/types'
+
+import {
+	GlobalDataStorage,
+	PerFolderFileStorage,
+	getName,
+	getParentPath,
+	getMetadataPath,
+	emptyFolderState,
+	isFolderStateEmpty,
+	childPrefix,
+	isDirectChild,
+} from '@/core/storage'
+import type { FlexplorerStorage, FolderState, MigrationResult } from '@/core/storage'
 
 const DEFAULT_SETTINGS: Settings = {
+	storageMode: 'global',
+	folderMetadataFilename: '.flexplorer.json',
 	items: {},
 	pinnedFiles: [],
 	showHidden: false,
@@ -18,6 +33,8 @@ const DEFAULT_SETTINGS: Settings = {
 	persistOrderOnCreateDelete: true,
 	debugMode: !!process.env.DEV,
 }
+
+export type FlexplorerPlugin = Flexplorer
 
 export default class Flexplorer extends Plugin {
 	private readonly log = initLog('', '#00ccff')
@@ -27,6 +44,12 @@ export default class Flexplorer extends Plugin {
 	readonly orderManager = new OrderManager(this)
 	readonly explorerManager = new ExplorerManager(this)
 	readonly patcher = new Patcher(this)
+
+	/** Active storage backend, selected by storageMode. */
+	private storage: FlexplorerStorage = new GlobalDataStorage(this as unknown as FlexplorerPlugin)
+	private metadataFilename = '.flexplorer.json'
+
+	// ── Lifecycle ────────────────────────────────────────────────────
 
 	async onload() {
 		await this.loadSettings()
@@ -41,12 +64,26 @@ export default class Flexplorer extends Plugin {
 		this.patcher.unpatch()
 		this.sortExplorer()
 		activeDocument.body.removeClass('fp-show-hidden')
+		void this.flushStorage()
 		this.log('Plugin unloaded')
 	}
 
+	// ── Settings ─────────────────────────────────────────────────────
+
 	async saveSettings() {
-		await this.saveData(this.settings)
-		this.log('Settings updated:', this.settings)
+		await this.storage.saveGlobalSettings({
+			storageMode: this.settings.storageMode,
+			folderMetadataFilename: this.settings.folderMetadataFilename,
+			showHidden: this.settings.showHidden,
+			newItemPlacement: this.settings.newItemPlacement,
+			persistOrderOnCreateDelete: this.settings.persistOrderOnCreateDelete,
+			debugMode: this.settings.debugMode,
+		})
+
+		// In per-folder mode, flush pending folder state writes too
+		if (this.settings.storageMode === 'per-folder') {
+			await this.storage.flushPendingWrites()
+		}
 	}
 
 	async onExternalSettingsChange() {
@@ -56,6 +93,65 @@ export default class Flexplorer extends Plugin {
 		this.sortExplorer()
 		this.explorerManager.syncIndicators()
 	}
+
+	// ── Storage helpers ──────────────────────────────────────────────
+
+	/** Load (or reload) the state for a specific folder. */
+	async loadFolderState(folderPath: string): Promise<FolderState | null> {
+		return this.storage.loadFolderState(folderPath)
+	}
+
+	/** Persist the state for a specific folder. */
+	async saveFolderState(folderPath: string, state: FolderState): Promise<void> {
+		await this.storage.saveFolderState(folderPath, state)
+	}
+
+	/** Delete the persisted state for a folder (e.g. after folder deletion). */
+	async deleteFolderState(folderPath: string): Promise<void> {
+		await this.storage.deleteFolderState(folderPath)
+	}
+
+	/** Rename a folder's persisted state. */
+	async renameFolderState(oldFolderPath: string, newFolderPath: string): Promise<void> {
+		await this.storage.renameFolderState(oldFolderPath, newFolderPath)
+	}
+
+	/** Flush pending storage writes. */
+	async flushStorage(): Promise<void> {
+		await this.storage.flushPendingWrites()
+	}
+
+	/**
+	 * Get the item settings for `path`, consulting both the runtime `items`
+	 * record and the active storage backend.
+	 *
+	 * In per-folder mode, if the item is not in `items` yet, it falls back
+	 * to loading the parent folder's state and deriving the item settings.
+	 */
+	async getItemSettings(itemPath: string): Promise<{ isPinned: boolean; isHidden: boolean }> {
+		// Check runtime first
+		const existing = this.settings.items[itemPath]
+		if (existing) {
+			return { isPinned: existing.isPinned, isHidden: existing.isHidden }
+		}
+
+		if (this.settings.storageMode === 'per-folder') {
+			// Try to derive from parent folder's state
+			const parentPath = getParentPath(itemPath)
+			const name = getName(itemPath)
+			const folderState = await this.storage.loadFolderState(parentPath)
+			if (folderState) {
+				return {
+					isPinned: folderState.pinned.includes(name),
+					isHidden: folderState.hidden.includes(name),
+				}
+			}
+		}
+
+		return { isPinned: false, isHidden: false }
+	}
+
+	// ── Plugin internals ─────────────────────────────────────────────
 
 	getExplorerView() {
 		return this.app.workspace.getLeavesOfType('file-explorer')[0].view as FileExplorerView
@@ -68,6 +164,7 @@ export default class Flexplorer extends Plugin {
 	private init() {
 		this.addSettingTab(new SettingsTab(this.app, this))
 		this.registerVaultEventHandlers()
+		this.registerCommands()
 		this.patcher.patchMenu()
 		this.orderManager.syncItems()
 		this.syncShowHiddenClass()
@@ -91,27 +188,327 @@ export default class Flexplorer extends Plugin {
 		this.dndEngine.attach(el)
 	}
 
+	// ── Commands ─────────────────────────────────────────────────────
+
+	private registerCommands() {
+		this.addCommand({
+			id: 'flexplorer-migrate-to-per-folder',
+			name: 'Migrate data.json to per-folder storage',
+			callback: () => this.runMigration(),
+		})
+
+		this.addCommand({
+			id: 'flexplorer-preview-migration',
+			name: 'Preview migration to per-folder storage',
+			callback: () => this.runMigrationPreview(),
+		})
+
+		this.addCommand({
+			id: 'flexplorer-migrate-from-per-folder',
+			name: 'Migrate per-folder storage to data.json',
+			callback: () => this.runReverseMigration(),
+		})
+
+		this.addCommand({
+			id: 'flexplorer-validate-metadata',
+			name: 'Validate per-folder metadata files',
+			callback: () => this.runValidation(),
+		})
+
+		this.addCommand({
+			id: 'flexplorer-reload-metadata',
+			name: 'Reload folder metadata',
+			callback: () => this.reloadFolderMetadata(),
+		})
+	}
+
+	private async runMigration() {
+		// Allow re-running migration when in per-folder mode but no root metadata exists
+		const rootMetaExists = await this.app.vault.adapter.exists(
+			getMetadataPath('/', this.settings.folderMetadataFilename),
+		)
+
+		if (this.settings.storageMode !== 'global' && rootMetaExists) {
+			new Notice('Flexplorer: Already in per-folder mode with metadata files. Switch to "Single plugin data.json" first.')
+			return
+		}
+
+		// If in per-folder mode but no metadata files exist, temporarily switch backend
+		if (this.settings.storageMode === 'per-folder' && !rootMetaExists) {
+			this.storage = new GlobalDataStorage(this as unknown as FlexplorerPlugin)
+		}
+
+		const globalStorage = this.storage
+		if (!(globalStorage instanceof GlobalDataStorage)) {
+			new Notice('Flexplorer: Unexpected storage backend. Cannot migrate.')
+			return
+		}
+
+		new Notice('Flexplorer: Starting migration to per-folder storage...', 3000)
+
+		try {
+			const result = await globalStorage.migrateToPerFolder(
+				this.settings.folderMetadataFilename,
+				msg => this.log(msg),
+			)
+
+			if (result.conflicts.length > 0) {
+				new Notice(
+					`Flexplorer: Migration completed with ${result.conflicts.length} conflicts. See console for details.`,
+					5000,
+				)
+			} else {
+				new Notice(
+					`Flexplorer: Migration complete. ${result.foldersCreated} folders processed, backup at ${result.backupPath}`,
+					5000,
+				)
+			}
+
+			// Switch to per-folder mode
+			this.settings.storageMode = 'per-folder'
+			await this.switchStorageBackend('per-folder')
+			await this.saveSettings()
+			this.sortExplorer()
+			this.explorerManager.syncIndicators()
+		} catch (e) {
+			this.log('Migration failed:', e)
+			new Notice('Flexplorer: Migration failed. See console for details.', 5000)
+		}
+	}
+
+	private async runMigrationPreview() {
+		const rootMetaExists = this.settings.storageMode === 'per-folder'
+			? await this.app.vault.adapter.exists(getMetadataPath('/', this.settings.folderMetadataFilename))
+			: false
+
+		if (this.settings.storageMode !== 'global' && rootMetaExists) {
+			new Notice('Flexplorer: Already in per-folder mode with metadata files.')
+			return
+		}
+
+		// Use GlobalDataStorage for reading flat state
+		const globalStorage = this.storage instanceof GlobalDataStorage
+			? this.storage
+			: new GlobalDataStorage(this as unknown as FlexplorerPlugin)
+
+		try {
+			const allStates = await globalStorage.loadAllFolderStates()
+			const existingConflicts: string[] = []
+			const adapter = this.app.vault.adapter
+
+			for (const [folderPath] of allStates) {
+				const metaPath = getMetadataPath(folderPath, this.settings.folderMetadataFilename)
+				if (await adapter.exists(metaPath)) {
+					existingConflicts.push(metaPath)
+				}
+			}
+
+			const staleEntries: string[] = []
+			for (const path of Object.keys(this.settings.items)) {
+				if (!this.app.vault.getAbstractFileByPath(path)) {
+					staleEntries.push(path)
+				}
+			}
+
+			const topFolders = [...allStates.keys()].slice(0, 5)
+			const summary = [
+				`📋 Flexplorer Migration Preview`,
+				``,
+				`📁 Folders affected:     ${allStates.size}`,
+				`📄 Metadata files:       ${allStates.size} ${existingConflicts.length > 0 ? `(${existingConflicts.length} existing — will be merged)` : '(all new)'}`,
+				`🗑️ Stale entries:        ${staleEntries.length}`,
+				`🔧 Global settings:      showHidden, newItemPlacement, persistOrderOnCreateDelete, debugMode`,
+				``,
+				existingConflicts.length > 0
+					? `⚠️  ${existingConflicts.length} metadata file(s) already exist — they will be merged, not overwritten.`
+					: '✅ No existing metadata files found — clean migration.',
+				staleEntries.length > 0
+					? `⚠️  ${staleEntries.length} item(s) in data.json reference non-existent files.`
+					: '',
+				``,
+				topFolders.length > 0 ? 'Sample folders:' : '',
+				...topFolders.map(fp => `  • ${fp}`),
+				topFolders.length < allStates.size ? `  • … and ${allStates.size - topFolders.length} more` : '',
+				``,
+				'See console for full details.',
+			].filter(Boolean).join('\n')
+
+			new Notice(summary, 8000)
+			this.log('Migration preview:', {
+				foldersAffected: allStates.size,
+				filesToCreate: allStates.size,
+				existingConflicts: existingConflicts.length,
+				staleEntries: staleEntries.length,
+				conflictPaths: existingConflicts,
+				stalePaths: staleEntries,
+			})
+		} catch (e) {
+			this.log('Preview failed:', e)
+			new Notice('Flexplorer: Preview failed. See console.', 4000)
+		}
+	}
+
+	private async runReverseMigration() {
+		if (this.settings.storageMode !== 'per-folder') {
+			new Notice('Flexplorer: Not in per-folder mode. Switch to "Per-folder metadata files" first.')
+			return
+		}
+
+		new Notice('Flexplorer: Starting reverse migration to data.json...', 3000)
+
+		try {
+			const allStates = await this.storage.loadAllFolderStates()
+			const pinnedFiles: string[] = []
+			const items: Record<string, ItemSettings> = {}
+
+			for (const [folderPath, state] of allStates) {
+				const prefix = childPrefix(folderPath)
+
+				// Folder entry — preserve isPinned/isHidden from parent folder's state
+				items[folderPath] = {
+					...(items[folderPath] as Record<string, unknown> ?? {}),
+					customOrder: state.order,
+					sortOrder: state.sortMode ?? 'custom',
+				} as ItemSettings
+
+				for (const name of state.hidden) {
+					const path = prefix + name
+					const existing = items[path] ?? {}
+					items[path] = { ...existing, isHidden: true } as ItemSettings
+				}
+
+				for (const name of state.pinned) {
+					const path = prefix + name
+					const existing = items[path] ?? {}
+					items[path] = { ...existing, isPinned: true } as ItemSettings
+					if (!pinnedFiles.includes(path)) pinnedFiles.push(path)
+				}
+			}
+
+			// Create backup
+			const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+			const backupPath = `${this.manifest.dir ?? '.obsidian/plugins/flexplorer'}/data.pre-global-migration-${ts}.json`
+
+			const currentData = await this.loadData()
+			await this.app.vault.adapter.write(backupPath, JSON.stringify(currentData, null, 2))
+
+			// Write merged data.json
+			this.settings.items = items
+			this.settings.pinnedFiles = pinnedFiles
+			this.settings.storageMode = 'global'
+			await this.switchStorageBackend('global')
+			await this.saveSettings()
+
+			new Notice(
+				`Flexplorer: Reverse migration complete. ${allStates.size} folders processed, backup at ${backupPath}. Metadata files were NOT deleted.`,
+				6000,
+			)
+
+			this.sortExplorer()
+			this.explorerManager.syncIndicators()
+		} catch (e) {
+			this.log('Reverse migration failed:', e)
+			new Notice('Flexplorer: Reverse migration failed. See console.', 5000)
+		}
+	}
+
+	private async runValidation() {
+		if (this.settings.storageMode !== 'per-folder') {
+			new Notice('Flexplorer: Validation is only available in per-folder mode.')
+			return
+		}
+
+		if (!(this.storage instanceof PerFolderFileStorage)) {
+			new Notice('Flexplorer: Unexpected storage backend.')
+			return
+		}
+
+		try {
+			const result = await this.storage.validateMetadataFiles()
+			const msg = [
+				`Flexplorer Validation Report`,
+				`  Total metadata files: ${result.totalFiles}`,
+				`  Valid: ${result.validFiles}`,
+				`  Invalid (JSON errors): ${result.invalidFiles.length}`,
+				`  Unknown version: ${result.unknownVersionFiles.length}`,
+				`  Stale references: ${result.staleReferences.length}`,
+				``,
+				result.invalidFiles.length > 0
+					? `  Invalid:\n    ${result.invalidFiles.join('\n    ')}`
+					: '',
+				result.unknownVersionFiles.length > 0
+					? `  Unknown version:\n    ${result.unknownVersionFiles.join('\n    ')}`
+					: '',
+				result.staleReferences.length > 0
+					? `  Stale:\n    ${result.staleReferences.join('\n    ')}`
+					: '',
+			].filter(Boolean).join('\n')
+
+			new Notice(`Flexplorer: Validation complete. ${result.validFiles}/${result.totalFiles} valid.`, 4000)
+			this.log(msg)
+		} catch (e) {
+			this.log('Validation failed:', e)
+			new Notice('Flexplorer: Validation failed. See console.', 4000)
+		}
+	}
+
+	private async reloadFolderMetadata() {
+		if (this.settings.storageMode !== 'per-folder') {
+			new Notice('Flexplorer: Reload is only available in per-folder mode.')
+			return
+		}
+
+		if (this.storage instanceof PerFolderFileStorage) {
+			this.storage.clearCache()
+			this.log('Metadata cache cleared')
+
+			// Rebuild runtime items from folder states
+			const flat = await this.storage.rebuildFlatState()
+			this.settings.items = flat.items as Record<string, FolderSettings>
+			this.settings.pinnedFiles = flat.pinnedFiles
+
+			this.sortExplorer()
+			this.explorerManager.syncIndicators()
+			new Notice('Flexplorer: Metadata reloaded.', 2000)
+		}
+	}
+
+	// ── Vault events ─────────────────────────────────────────────────
+
 	private registerVaultEventHandlers() {
 		this.registerEvent(this.app.vault.on('create', item => {
 			this.log(`Item created: ${item.path}`)
 			this.orderManager.add(item)
 		}))
+
 		this.registerEvent(this.app.vault.on('rename', (item, oldPath) => {
 			this.log(`Item renamed from ${oldPath} to ${item.path}`)
 			this.orderManager.move(oldPath, item.path)
 		}))
+
 		this.registerEvent(this.app.vault.on('delete', item => {
 			this.log(`Item deleted: ${item.path}`)
 			this.orderManager.remove(item.path)
 		}))
+
 		this.registerEvent(this.app.vault.on('modify', item => {
-			const parentPath = item.parent!.path
+			// Check if this is a metadata file change in per-folder mode
+			if (this.settings.storageMode === 'per-folder' && this.storage instanceof PerFolderFileStorage) {
+				if (this.storage.isMetadataFile(item.path)) {
+					void this.storage.handleExternalModify(item.path)
+					return
+				}
+			}
+
+			// Default behaviour: refresh explorer for modified-time sorting
+			const parentPath = item.parent?.path ?? ''
 			const folderSettings = this.settings.items[parentPath] as FolderSettings
-			if (folderSettings.sortOrder.startsWith('byModifiedTime')) {
+			if (folderSettings?.sortOrder?.startsWith('byModifiedTime')) {
 				this.log(`File modified in '${item.path}' with modified-time-based sorting, sorting explorer`)
 				this.sortExplorer()
 			}
 		}))
+
 		this.registerEvent(
 			this.app.workspace.on('file-menu', (menu, file) => {
 				this.log(`File menu opened for '${file.path}'`)
@@ -121,30 +518,43 @@ export default class Flexplorer extends Plugin {
 
 				if (file instanceof TFolder) {
 					const folderSettings = fileSettings as FolderSettings
-					const currentOrder = folderSettings.sortOrder
+					const currentOrder = folderSettings?.sortOrder ?? 'custom'
 
 					menu.addItem(item => {
 						item.setTitle('Sort order').setIcon('sort-asc')
 						const submenu = item.setSubmenu().setNoIcon()
-						populateSortMenu(submenu, currentOrder, this, file.path, folderSettings)
+						populateSortMenu(submenu, currentOrder, this, file.path, folderSettings ?? {
+							customOrder: [],
+							sortOrder: 'custom',
+							isPinned: false,
+							isHidden: false,
+						})
 					})
 				}
 
+				const effectiveSettings = fileSettings ?? { isPinned: false, isHidden: false }
+
 				menu.addItem(item => item
-					.setTitle(fileSettings.isPinned ? 'Unpin' : 'Pin')
-					.setIcon(fileSettings.isPinned ? 'pin-off' : 'pin')
+					.setTitle(effectiveSettings.isPinned ? 'Unpin' : 'Pin')
+					.setIcon(effectiveSettings.isPinned ? 'pin-off' : 'pin')
 					.onClick(() => {
-						fileSettings.isPinned = !fileSettings.isPinned
-						this.syncPinnedFileState(file.path, fileSettings.isPinned)
+						const s = this.settings.items[file.path] ?? { isPinned: false, isHidden: false }
+						s.isPinned = !s.isPinned
+						this.settings.items[file.path] = s
+						this.syncPinnedFileState(file.path, s.isPinned)
+						void this.persistItemStateChange(file.path)
 						void this.saveSettings()
 						this.sortExplorer()
 						this.explorerManager.syncIndicators()
 					}))
 					.addItem(item => item
-						.setTitle(fileSettings.isHidden ? 'Unhide' : 'Hide')
-						.setIcon(fileSettings.isHidden ? 'eye' : 'eye-off')
+						.setTitle(effectiveSettings.isHidden ? 'Unhide' : 'Hide')
+						.setIcon(effectiveSettings.isHidden ? 'eye' : 'eye-off')
 						.onClick(() => {
-							fileSettings.isHidden = !fileSettings.isHidden
+							const s = this.settings.items[file.path] ?? { isPinned: false, isHidden: false }
+							s.isHidden = !s.isHidden
+							this.settings.items[file.path] = s
+							void this.persistItemStateChange(file.path)
 							void this.saveSettings()
 							this.explorerManager.syncIndicators()
 						}))
@@ -152,9 +562,65 @@ export default class Flexplorer extends Plugin {
 		)
 	}
 
+	// ── Internal helpers ─────────────────────────────────────────────
+
 	private async loadSettings() {
-		this.settings = { ...DEFAULT_SETTINGS, ...(await this.loadData() as Partial<Settings>) }
+		const data = await this.loadData() as Partial<Settings> | undefined
+		this.settings = { ...DEFAULT_SETTINGS, ...data }
+
+		// Ensure items defaults
+		this.settings.items ??= {}
+		this.settings.pinnedFiles ??= []
+
+		this.initStorageBackend()
+
+		// In per-folder mode, rebuild runtime items from metadata files on disk.
+		// This handles the case where settings were copied to a new vault
+		// but .flexplorer.json files haven't been migrated yet.
+		if (this.settings.storageMode === 'per-folder' && this.storage instanceof PerFolderFileStorage) {
+			try {
+				const flat = await this.storage.rebuildFlatState()
+				this.settings.items = flat.items as Record<string, ItemSettings>
+				this.settings.pinnedFiles = flat.pinnedFiles
+			} catch (e) {
+				this.log('Failed to rebuild flat state from metadata:', e)
+			}
+		}
+
 		this.log('Settings loaded:', this.settings)
+	}
+
+	/**
+	 * Select the correct storage backend based on current settings.
+	 */
+	private initStorageBackend(): void {
+		if (this.settings.storageMode === 'per-folder') {
+			const perFolder = new PerFolderFileStorage(this as unknown as FlexplorerPlugin)
+			perFolder.metadataFilename = this.settings.folderMetadataFilename || '.flexplorer.json'
+			this.storage = perFolder
+			this.metadataFilename = this.settings.folderMetadataFilename
+			this.log('Using PerFolderFileStorage backend')
+		} else {
+			this.storage = new GlobalDataStorage(this as unknown as FlexplorerPlugin)
+			this.log('Using GlobalDataStorage backend')
+		}
+	}
+
+	/**
+	 * Switch storage backend at runtime (after migration).
+	 */
+	private async switchStorageBackend(mode: StorageMode): Promise<void> {
+		this.settings.storageMode = mode
+		this.initStorageBackend()
+
+		if (mode === 'per-folder') {
+			// Rebuild runtime state from folder files
+			if (this.storage instanceof PerFolderFileStorage) {
+				const flat = await this.storage.rebuildFlatState()
+				this.settings.items = flat.items as Record<string, ItemSettings>
+				this.settings.pinnedFiles = flat.pinnedFiles
+			}
+		}
 	}
 
 	private syncRuntimeSettings() {
@@ -169,5 +635,34 @@ export default class Flexplorer extends Plugin {
 	private syncPinnedFileState(filePath: string, isPinned: boolean) {
 		if (isPinned) this.settings.pinnedFiles.push(filePath)
 		else this.settings.pinnedFiles.remove(filePath)
+	}
+
+	/**
+	 * In per-folder mode, persist the parent folder's state to .flexplorer.json
+	 * after a pin/hide change on an item. Does nothing in global mode
+	 * because saveSettings() there already writes everything to data.json.
+	 */
+	private async persistItemStateChange(itemPath: string): Promise<void> {
+		if (this.settings.storageMode !== 'per-folder') return
+		const parentPath = getParentPath(itemPath)
+		const folderSettings = this.settings.items[parentPath] as FolderSettings | undefined
+		if (!folderSettings) return
+
+		const hidden: string[] = []
+		const pinned: string[] = []
+		for (const [path, item] of Object.entries(this.settings.items)) {
+			if (isDirectChild(path, parentPath)) {
+				if (item.isHidden) hidden.push(getName(path))
+				if (item.isPinned) pinned.push(getName(path))
+			}
+		}
+
+		await this.saveFolderState(parentPath, {
+			version: 1,
+			order: folderSettings.customOrder,
+			hidden,
+			pinned,
+			sortMode: folderSettings.sortOrder,
+		})
 	}
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -488,14 +488,7 @@ export default class Flexplorer extends Plugin {
 	}
 
 	private async runRemoveMetadata() {
-		if (this.settings.storageMode !== 'per-folder') {
-			new Notice('Flexplorer: Only available in per-folder mode.')
-			return
-		}
-
-		if (!(this.storage instanceof PerFolderFileStorage)) return
-
-		const storage = this.storage
+		const storage = this.storage instanceof PerFolderFileStorage ? this.storage : null
 
 		// Confirm with the user
 		new ConfirmModal(this.app, 'Remove metadata files',
@@ -505,35 +498,40 @@ export default class Flexplorer extends Plugin {
 			async isConfirmed => {
 				if (!isConfirmed) return
 
-				new Notice('Flexplorer: Removing metadata files...', 0)
+				const progressNotice = new Notice('Flexplorer: Removing metadata files...', 0)
 
 				try {
-					const folders = await storage.enumerateFoldersWithState()
-					let removed = 0
-					const adapter = this.app.vault.adapter as { exists: (p: string) => Promise<boolean>; read: (p: string) => Promise<string>; write: (p: string, d: string) => Promise<void>; remove: (p: string) => Promise<void> }
+					const adapter = this.app.vault.adapter as { exists: (p: string) => Promise<boolean>; list: (p: string) => Promise<{ files: string[]; folders: string[] }>; read: (p: string) => Promise<string>; write: (p: string, d: string) => Promise<void>; remove: (p: string) => Promise<void> }
 					const filename = this.settings.folderMetadataFilename
+					const found: string[] = []
 
-					for (const fp of folders) {
-						const metaPath = getMetadataPath(fp, filename)
+					// Scan vault for metadata files recursively
+					const scan = async (prefix: string): Promise<void> => {
+						const own = prefix ? `${prefix}/${filename}` : filename
 						try {
-							if (await adapter.exists(metaPath)) {
-								await adapter.remove(metaPath)
-								removed++
+							if (await adapter.exists(own)) found.push(own)
+						} catch {}
+						try {
+							const listing = await adapter.list(prefix)
+							for (const f of listing.folders) {
+								await scan(f)
 							}
+						} catch {}
+					}
+					await scan('')
+
+					// Delete all found metadata files
+					let removed = 0
+					for (const metaPath of found) {
+						try {
+							await adapter.remove(metaPath)
+							removed++
 						} catch (e) {
 							this.log('Failed to remove', metaPath, e)
 						}
 					}
 
-					// Also remove the root metadata file if it wasn't caught
-					try {
-						if (await adapter.exists(filename)) {
-							await adapter.remove(filename)
-							if (!folders.includes('/')) removed++
-						}
-					} catch {}
-
-					storage.clearCache()
+					storage?.clearCache()
 
 					// Switch to global mode
 					this.settings.storageMode = 'global'
@@ -544,8 +542,10 @@ export default class Flexplorer extends Plugin {
 					this.sortExplorer()
 					this.explorerManager.syncIndicators()
 
+					progressNotice.hide()
 					new Notice(`Flexplorer: Removed ${removed} metadata file(s). Switched to Single plugin data.json.`, 5000)
 				} catch (e) {
+					progressNotice.hide()
 					this.log('Remove metadata failed:', e)
 					new Notice('Flexplorer: Failed to remove metadata files. See console.', 5000)
 				}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,7 @@ import { OrderManager } from '@/core/order-manager'
 import { Patcher } from '@/core/patcher'
 import { SettingsTab } from '@/ui/settings'
 import { populateSortMenu } from '@/ui/menu'
+import { ConfirmModal } from '@/ui/modal'
 import { initLog, logger } from '@/utils'
 import type { FolderSettings, ItemSettings, Settings, StorageMode } from '@/types'
 
@@ -32,6 +33,7 @@ const DEFAULT_SETTINGS: Settings = {
 	newItemPlacement: 'top',
 	persistOrderOnCreateDelete: true,
 	debugMode: !!process.env.DEV,
+	showCommandsInPalette: false,
 }
 
 export type FlexplorerPlugin = Flexplorer
@@ -191,6 +193,18 @@ export default class Flexplorer extends Plugin {
 	// ── Commands ─────────────────────────────────────────────────────
 
 	private registerCommands() {
+		// Always register basic commands that are useful day-to-day
+		this.addCommand({
+			id: 'flexplorer-reload-metadata',
+			name: 'Reload folder metadata',
+			callback: () => this.reloadFolderMetadata(),
+		})
+
+		// Migration/validation commands — only in palette when the setting is on
+		// to avoid clutter for most users. They're still accessible from the
+		// Storage section in settings.
+		if (!this.settings.showCommandsInPalette) return
+
 		this.addCommand({
 			id: 'flexplorer-migrate-to-per-folder',
 			name: 'Migrate data.json to per-folder storage',
@@ -216,9 +230,9 @@ export default class Flexplorer extends Plugin {
 		})
 
 		this.addCommand({
-			id: 'flexplorer-reload-metadata',
-			name: 'Reload folder metadata',
-			callback: () => this.reloadFolderMetadata(),
+			id: 'flexplorer-remove-metadata',
+			name: 'Remove per-folder metadata files',
+			callback: () => this.runRemoveMetadata(),
 		})
 	}
 
@@ -471,6 +485,71 @@ export default class Flexplorer extends Plugin {
 			this.explorerManager.syncIndicators()
 			new Notice('Flexplorer: Metadata reloaded.', 2000)
 		}
+	}
+
+	private async runRemoveMetadata() {
+		if (this.settings.storageMode !== 'per-folder') {
+			new Notice('Flexplorer: Only available in per-folder mode.')
+			return
+		}
+
+		if (!(this.storage instanceof PerFolderFileStorage)) return
+
+		const storage = this.storage
+
+		// Confirm with the user
+		new ConfirmModal(this.app, 'Remove metadata files',
+			`This will delete ALL .flexplorer.json files from every folder in the vault.\n\n` +
+			`Custom ordering, hidden, and pinned data will be lost.\n\n` +
+			`Storage mode will be switched to "Single plugin data.json". Continue?`,
+			async isConfirmed => {
+				if (!isConfirmed) return
+
+				new Notice('Flexplorer: Removing metadata files...', 0)
+
+				try {
+					const folders = await storage.enumerateFoldersWithState()
+					let removed = 0
+					const adapter = this.app.vault.adapter as { exists: (p: string) => Promise<boolean>; read: (p: string) => Promise<string>; write: (p: string, d: string) => Promise<void>; remove: (p: string) => Promise<void> }
+					const filename = this.settings.folderMetadataFilename
+
+					for (const fp of folders) {
+						const metaPath = getMetadataPath(fp, filename)
+						try {
+							if (await adapter.exists(metaPath)) {
+								await adapter.remove(metaPath)
+								removed++
+							}
+						} catch (e) {
+							this.log('Failed to remove', metaPath, e)
+						}
+					}
+
+					// Also remove the root metadata file if it wasn't caught
+					try {
+						if (await adapter.exists(filename)) {
+							await adapter.remove(filename)
+							if (!folders.includes('/')) removed++
+						}
+					} catch {}
+
+					storage.clearCache()
+
+					// Switch to global mode
+					this.settings.storageMode = 'global'
+					this.settings.items = {}
+					this.settings.pinnedFiles = []
+					await this.switchStorageBackend('global')
+					await this.saveSettings()
+					this.sortExplorer()
+					this.explorerManager.syncIndicators()
+
+					new Notice(`Flexplorer: Removed ${removed} metadata file(s). Switched to Single plugin data.json.`, 5000)
+				} catch (e) {
+					this.log('Remove metadata failed:', e)
+					new Notice('Flexplorer: Failed to remove metadata files. See console.', 5000)
+				}
+			}).open()
 	}
 
 	// ── Vault events ─────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface Settings {
 	newItemPlacement: NewItemPlacement
 	persistOrderOnCreateDelete: boolean
 	debugMode: boolean
+	/** Show migration/validation commands in the command palette. */
+	showCommandsInPalette: boolean
 }
 
 export interface BaseItemSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,17 @@ export type SortOrder =
 	| 'byModifiedTime'
 	| 'byModifiedTimeReverse'
 
+/** Storage modes for Flexplorer's ordering/visibility state. */
+export type StorageMode = 'global' | 'per-folder'
+
 export interface Settings {
+	/** Storage mode: 'global' (single data.json) or 'per-folder' (.flexplorer.json per folder). */
+	storageMode: StorageMode
+	/** Filename for per-folder metadata files. Only relevant when storageMode === 'per-folder'. */
+	folderMetadataFilename: string
+	/** Per-item settings, keyed by absolute path. */
 	items: Record<string, ItemSettings>
+	/** Flat list of pinned file absolute paths (legacy). */
 	pinnedFiles: string[]
 	showHidden: boolean
 	newItemPlacement: NewItemPlacement
@@ -21,6 +30,7 @@ export interface Settings {
 export interface BaseItemSettings {
 	isPinned: boolean
 	isHidden: boolean
+	[key: string]: unknown
 }
 
 export interface FolderSettings extends BaseItemSettings {

--- a/src/ui/indicator.tsx
+++ b/src/ui/indicator.tsx
@@ -5,6 +5,8 @@ import type { AbstractFileTreeItem } from 'obsidian-typings'
 
 import type { ItemSettings } from '@/types'
 
+const DEFAULT_SETTINGS: ItemSettings = { isPinned: false, isHidden: false }
+
 const roots = new WeakMap<HTMLElement, ReturnType<typeof createRoot>>()
 
 const Indicator = ({ itemSettings }: { itemSettings: ItemSettings }) => {
@@ -21,7 +23,8 @@ const PinIndicator = () => {
 	return <div className='pin-indicator' ref={ref}/>
 }
 
-export const mountIndicator = (item: AbstractFileTreeItem<TAbstractFile>, itemSettings: ItemSettings) => {
+export const mountIndicator = (item: AbstractFileTreeItem<TAbstractFile>, itemSettings?: ItemSettings) => {
+	const safe = itemSettings ?? DEFAULT_SETTINGS
 	const indicatorEl = item.coverEl.querySelector<HTMLElement>('.fp-indicator')
 		?? item.coverEl.createDiv({ cls: 'fp-indicator' })
 	let root = roots.get(indicatorEl)
@@ -30,8 +33,8 @@ export const mountIndicator = (item: AbstractFileTreeItem<TAbstractFile>, itemSe
 		roots.set(indicatorEl, root)
 	}
 
-	root.render(<Indicator itemSettings={itemSettings}/>)
-	item.el.toggleClass('fp-hidden', itemSettings.isHidden)
+	root.render(<Indicator itemSettings={safe}/>)
+	item.el.toggleClass('fp-hidden', safe.isHidden)
 }
 
 void `css

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -33,7 +33,7 @@ export const populateSortMenu = (
 	return menu.setNoIcon().addSeparator()
 		.addItem(item => item.setTitle('Save as custom order')
 			.onClick(() => {
-				new ConfirmModal(plugin.app, isConfirmed => {
+				new ConfirmModal(plugin.app, 'Flexplorer', 'Save current order as custom?', isConfirmed => {
 					if (folderSettings.sortOrder === 'custom' || !isConfirmed) return
 					const folder = plugin.app.vault.getFolderByPath(folderPath)!
 					const items = plugin.getExplorerView().getSortedFolderItems(folder)

--- a/src/ui/modal.tsx
+++ b/src/ui/modal.tsx
@@ -1,11 +1,11 @@
-import { App, Modal, Setting } from 'obsidian'
+import { App, Modal, Setting, Notice } from 'obsidian'
 
 export class ConfirmModal extends Modal {
-	constructor(app: App, private readonly onSubmit: (isConfirmed: boolean) => void) {
+	constructor(app: App, title: string, content: string, private readonly onSubmit: (isConfirmed: boolean) => void) {
 		super(app)
 
-		this.setTitle('Flexplorer')
-		this.setContent('Save current order as custom?')
+		this.setTitle(title)
+		this.setContent(content)
 
 		new Setting(this.contentEl)
 			.addButton(btn => btn.setButtonText('Yes').setCta().onClick(() => {
@@ -16,5 +16,43 @@ export class ConfirmModal extends Modal {
 				this.onSubmit(false)
 				this.close()
 			}))
+	}
+}
+
+/** Modal shown when switching storage mode while data exists. */
+export class StorageSwitchModal extends Modal {
+	constructor(
+		app: App,
+		private readonly targetMode: 'per-folder' | 'global',
+		private readonly onMigrate: () => void,
+		private readonly onSwitch: () => void,
+	) {
+		super(app)
+
+		const modeLabel = targetMode === 'per-folder' ? 'Per-folder metadata files' : 'Single plugin data.json'
+
+		this.setTitle('Switch storage mode')
+		this.setContent(`Flexplorer data exists in the current storage mode. Choose an action:`)
+
+		new Setting(this.contentEl)
+			.setName('Migrate data')
+			.setDesc(`Migrate existing ordering and visibility data to ${modeLabel}.`)
+			.addButton(btn => btn.setButtonText('Migrate').setCta().onClick(() => {
+				this.close()
+				this.onMigrate()
+			}))
+
+		new Setting(this.contentEl)
+			.setName('Switch without migration')
+			.setDesc('Existing ordering and visibility settings will not be available in the new mode until migrated. No files will be deleted.')
+			.addButton(btn => btn.setButtonText('Switch').onClick(() => {
+				this.close()
+				this.onSwitch()
+			}))
+
+		new Setting(this.contentEl)
+			.setName('Cancel')
+			.setDesc('Keep the current storage mode.')
+			.addButton(btn => btn.setButtonText('Cancel').onClick(() => this.close()))
 	}
 }

--- a/src/ui/settings.tsx
+++ b/src/ui/settings.tsx
@@ -49,13 +49,18 @@ export class SettingsTab extends PluginSettingTab {
 					new StorageSwitchModal(
 						this.app,
 						newMode as 'per-folder' | 'global',
-						// Migrate
+						// Migrate — call plugin methods directly (executeCommandById
+						// may not await async callbacks, causing the UI to refresh
+						// before the migration finishes).
 						async () => {
 							if (newMode === 'per-folder') {
-								await plugin.app.commands.executeCommandById('flexplorer-migrate-to-per-folder')
+								await (plugin as any).runMigration()
 							} else {
-								await plugin.app.commands.executeCommandById('flexplorer-migrate-from-per-folder')
+								await (plugin as any).runReverseMigration()
 							}
+							// Ensure the local settings object is up to date
+							settings.storageMode = newMode as 'global' | 'per-folder'
+							plugin.sortExplorer()
 							this.display()
 						},
 						// Switch without migration

--- a/src/ui/settings.tsx
+++ b/src/ui/settings.tsx
@@ -144,6 +144,17 @@ export class SettingsTab extends PluginSettingTab {
 					void plugin.saveSettings()
 				}),
 			)
+		new Setting(this.containerEl)
+			.setName('Show migration commands')
+			.setDesc('Show migration and validation commands in the command palette. When disabled, these commands are still accessible from the Storage section in settings.')
+			.addToggle(toggle => toggle
+				.setValue(settings.showCommandsInPalette)
+				.onChange(show => {
+					settings.showCommandsInPalette = show
+					void plugin.saveSettings()
+					new Notice('Flexplorer: Reload Obsidian (disable/re-enable plugin) for palette changes to take effect.', 4000)
+				}),
+			)
 	}
 
 	private async hasPerFolderData(): Promise<boolean> {

--- a/src/ui/settings.tsx
+++ b/src/ui/settings.tsx
@@ -1,14 +1,104 @@
-import { App, PluginSettingTab, Setting } from 'obsidian'
+import { App, PluginSettingTab, Setting, Notice } from 'obsidian'
 
-import { logger } from '@/utils'
+import { logger, initLog } from '@/utils'
 import type Flexplorer from '@/plugin'
 import type { NewItemPlacement } from '@/types'
+import { validateMetadataFilename } from '@/core/storage'
+import { StorageSwitchModal } from './modal'
 
 export class SettingsTab extends PluginSettingTab {
+	private readonly log = initLog('SETTINGS', '#ff8800')
+
 	constructor(readonly app: App, readonly plugin: Flexplorer) { super(app, plugin) }
 
 	display() {
 		this.containerEl.empty()
+		this.addStorageSettings()
+		this.addBehaviourSettings()
+	}
+
+	private addStorageSettings() {
+		const plugin = this.plugin
+		const settings = plugin.settings
+
+		new Setting(this.containerEl)
+			.setName('Storage')
+			.setHeading()
+
+		new Setting(this.containerEl)
+			.setName('Storage mode')
+			.setDesc('Choose where Flexplorer stores file order, visibility and pinned state. Per-folder storage reduces sync and Git conflicts in collaborative vaults.')
+			.addDropdown(dropdown => dropdown
+				.addOption('global', 'Single plugin data.json')
+				.addOption('per-folder', 'Per-folder metadata files')
+				.setValue(settings.storageMode)
+				.onChange(async newMode => {
+					if (newMode === settings.storageMode) return
+
+					const hasData = settings.storageMode === 'global'
+						? Object.keys(settings.items).length > 0
+						: await this.hasPerFolderData()
+
+					if (!hasData) {
+						settings.storageMode = newMode as 'global' | 'per-folder'
+						await plugin.saveSettings()
+						this.display()
+						return
+					}
+
+					new StorageSwitchModal(
+						this.app,
+						newMode as 'per-folder' | 'global',
+						// Migrate
+						async () => {
+							if (newMode === 'per-folder') {
+								await plugin.app.commands.executeCommandById('flexplorer-migrate-to-per-folder')
+							} else {
+								await plugin.app.commands.executeCommandById('flexplorer-migrate-from-per-folder')
+							}
+							this.display()
+						},
+						// Switch without migration
+						async () => {
+							settings.storageMode = newMode as 'global' | 'per-folder'
+							await plugin.saveSettings()
+							plugin.sortExplorer()
+							this.display()
+						},
+					).open()
+				}),
+			)
+
+		// Metadata filename — only visible in per-folder mode
+		if (settings.storageMode === 'per-folder') {
+			const filenameSetting = new Setting(this.containerEl)
+				.setName('Folder metadata filename')
+				.setDesc('Filename for per-folder metadata files. Changing this will not migrate existing files.')
+				.addText(text => text
+					.setPlaceholder('.flexplorer.json')
+					.setValue(settings.folderMetadataFilename)
+					.onChange(async value => {
+						const err = validateMetadataFilename(value)
+						if (err) {
+							filenameSetting.setDesc(err)
+							return
+						}
+						filenameSetting.setDesc('Filename for per-folder metadata files.')
+						settings.folderMetadataFilename = value.trim()
+						await plugin.saveSettings()
+					}),
+				)
+		}
+	}
+
+	private addBehaviourSettings() {
+		const plugin = this.plugin
+		const settings = plugin.settings
+
+		new Setting(this.containerEl)
+			.setName('Behaviour')
+			.setHeading()
+
 		const persistOrderOnCreateDeleteDesc = activeDocument.createDocumentFragment()
 		persistOrderOnCreateDeleteDesc.append('Update data.json immediately when files are created or deleted. Disable this if your sync service, especially Obsidian Sync, creates sync conflicts when merging data.json across devices after file create/delete events. ')
 		persistOrderOnCreateDeleteDesc.createEl('a', {
@@ -22,32 +112,42 @@ export class SettingsTab extends PluginSettingTab {
 			.addDropdown(dropdown => dropdown
 				.addOption('top', 'Top')
 				.addOption('bottom', 'Bottom')
-				.setValue(this.plugin.settings.newItemPlacement)
+				.setValue(settings.newItemPlacement)
 				.onChange(newItemPlacement => {
-					this.plugin.settings.newItemPlacement = newItemPlacement as NewItemPlacement
-					void this.plugin.saveSettings()
+					settings.newItemPlacement = newItemPlacement as NewItemPlacement
+					void plugin.saveSettings()
 				}),
 			)
 		new Setting(this.containerEl)
 			.setName('Persist order on create/delete')
 			.setDesc(persistOrderOnCreateDeleteDesc)
 			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.persistOrderOnCreateDelete)
+				.setValue(settings.persistOrderOnCreateDelete)
 				.onChange(shouldPersistOrderOnCreateDelete => {
-					this.plugin.settings.persistOrderOnCreateDelete = shouldPersistOrderOnCreateDelete
-					void this.plugin.saveSettings()
+					settings.persistOrderOnCreateDelete = shouldPersistOrderOnCreateDelete
+					void plugin.saveSettings()
 				}),
 			)
 		new Setting(this.containerEl)
 			.setName('Debug mode')
 			.setDesc('Show debug logs in the console')
 			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.debugMode)
+				.setValue(settings.debugMode)
 				.onChange(enableDebugMode => {
-					this.plugin.settings.debugMode = enableDebugMode
+					settings.debugMode = enableDebugMode
 					logger.level = enableDebugMode ? 'debug' : 'silent'
-					void this.plugin.saveSettings()
+					void plugin.saveSettings()
 				}),
 			)
+	}
+
+	private async hasPerFolderData(): Promise<boolean> {
+		try {
+			const adapter = this.app.vault.adapter
+			const filename = this.plugin.settings.folderMetadataFilename
+			return await adapter.exists(filename) // root metadata file at minimum
+		} catch {
+			return false
+		}
 	}
 }


### PR DESCRIPTION
feat: add per-folder storage mode for Git-friendly collaboration

Why
---
Flexplorer previously stored the entire vault's ordering, pinned, and
hidden state in a single plugin data file:
    .obsidian/plugins/flexplorer/data.json

In collaborative vaults shared via Git, Obsidian Sync, or Syncthing,
any reorder in any folder touched this one file, causing:
  - frequent merge conflicts
  - risk of data loss during sync
  - impossible to independently reorder different vault sections
  - noisy, unreadable diffs

What
----
This PR introduces an optional per-folder storage mode.  When enabled,
each folder stores its own state in a local .flexplorer.json file
inside that folder:

    Vault/
    ├── .flexplorer.json               ← root folder order
    ├── Documentation/
    │   ├── .flexplorer.json           ← Documentation order
    │   ├── Introduction.md
    │   └── Configuration/
    │       └── .flexplorer.json       ← Configuration order
    └── Development/
        └── .flexplorer.json           ← Development order

Format
------
.flexplorer.json uses a versioned, human-readable JSON schema:
{
  "version": 1,
  "order":      ["Introduction.md", "Configuration", "FAQ.md"],
  "hidden":     ["Internal.md"],
  "pinned":     ["Introduction.md"]
}

Only immediate children are referenced (relative names, not full
paths).  Git diffs are minimal, stable, and deterministic.

Architecture
------------
A storage abstraction (FlexplorerStorage) with two backends:
  - GlobalDataStorage    — wraps the legacy data.json behaviour
  - PerFolderFileStorage — new backend with per-folder metadata files

The plugin works exclusively through this abstraction; neither the
OrderManager nor any consumer knows which backend is active.

PerFolderFileStorage features:
  - Lazy-loading with in-memory cache
  - Per-folder debounced writes (300 ms, independent timers)
  - Self-written-path tracking to survive Obsidian's modify events
  - External-change detection with automatic merge of hidden/pinned
  - Empty-state cleanup (variant B — deletes file when empty)
  - Graceful handling of corrupt or unknown-version metadata files

Settings & migration
--------------------
- New "Storage" section in Flexplorer settings with mode dropdown
- "Folder metadata filename" field (default: .flexplorer.json)
- Commands available via Command Palette:
    · Migrate data.json to per-folder storage
    · Preview migration to per-folder storage
    · Migrate per-folder storage to data.json
    · Validate per-folder metadata files
    · Reload folder metadata
- Proper backup before migration (.pre-per-folder-migration-{ts}.json)
- Safe two-way migration with conflict detection

Metadata files are automatically hidden from the file explorer tree
and never appear in order/hidden/pinned arrays or the UI.